### PR TITLE
agent: capture and control the Windows lock/sign-in screen

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -5898,6 +5898,7 @@ dependencies = [
  "dirs",
  "enigo",
  "futures-util",
+ "iana-time-zone",
  "image",
  "ipconfig",
  "libwayshot-xcap",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -96,6 +96,9 @@ windows = { version = "0.62", features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Shell",
     "Win32_System_Threading",
+    # Secure/lock-screen capture: attach the capture worker's threads to the
+    # desktop that currently owns input (Default vs. Winlogon).
+    "Win32_System_StationsAndDesktops",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_Storage_FileSystem",
     "Win32_Graphics_Gdi",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -58,6 +58,11 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 url = "2"
 uuid = { version = "1", features = ["v4"] }
 
+# Resolve the machine's IANA timezone name (maps Windows tz ids -> IANA). Reported
+# in `agent_info` so the server can bucket Recall days in the user's *local* day
+# rather than a UTC one.
+iana-time-zone = "0.1"
+
 # Windows DPAPI: encrypt `config.dat` at rest (tied to this user + machine).
 # ── Logging ───────────────────────────────────────────────────────────────────
 tracing            = "0.1"

--- a/agent/src/agent_loop.rs
+++ b/agent/src/agent_loop.rs
@@ -1,10 +1,32 @@
 //! Agent Tokio runtime: IPC/WebSocket session, telemetry, and screen fan-in.
 
+use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
     Arc, Mutex,
 };
 use std::time::Duration;
+
+/// How often the session sweeps the keyframe spool for backlog and ack timeouts.
+const HISTORY_PUMP_INTERVAL_SECS: u64 = 5;
+/// Keyframes allowed on the wire without an ack. Bounded so a reconnect backlog
+/// drains steadily instead of dumping thousands of frames into the socket at once
+/// and starving live telemetry behind them.
+const HISTORY_MAX_IN_FLIGHT: usize = 4;
+/// Re-send a keyframe if the server hasn't acked it within this long.
+const HISTORY_ACK_TIMEOUT: Duration = Duration::from_secs(90);
+/// Magic prefix marking a binary WebSocket frame as a Recall keyframe, alongside the
+/// existing `AUD\0` (audio) / bare-JPEG (MJPEG) conventions on the same socket.
+/// Keep in sync with `HISTORY_FRAME_MAGIC` in `server/src/ws_agent.rs`.
+const HISTORY_FRAME_MAGIC: &[u8; 4] = b"HST\0";
+
+/// A spooled keyframe handed to the server, awaiting its ack.
+#[derive(Debug, Clone)]
+struct InFlightFrame {
+    path: PathBuf,
+    sent_at: std::time::Instant,
+}
 
 /// Wall-clock epoch milliseconds (used as the screen-history "last input" activity stamp).
 fn now_epoch_ms() -> u64 {
@@ -177,21 +199,55 @@ pub async fn run_agent_loop(
     // ── Screen history ("Recall") capture ─────────────────────────────────────
     // A slow, deduped keyframe pipeline independent of the demand-driven MJPEG
     // capture above. Spawned once for the process lifetime; `history_active`
-    // gates capture on the user being non-AFK. `history_rx` is drained inside
-    // `run_session`, and the select branch there is gated on `history_enabled`
-    // so a disabled/failed pipeline never busy-polls a closed channel.
+    // gates capture on the user being non-AFK.
+    //
+    // Capture never talks to the session directly. It feeds a dedicated drain
+    // thread that writes every keyframe to the durable on-disk spool, and the
+    // session ships frames *from the spool*, deleting each only once the server
+    // acks it. That is what makes the timeline survive disconnects, reconnect
+    // backoff, and agent restarts instead of silently losing those frames.
     let history_active = Arc::new(AtomicBool::new(true));
     // Epoch-ms of the last user interaction (keystroke / window switch / return from
     // AFK). The capture thread reads this to speed up while the user is actively using
     // the machine and slow down when they're not. Seed to "now" so we don't start hot.
     let history_last_input = Arc::new(AtomicU64::new(now_epoch_ms()));
-    let (history_tx, mut history_rx) =
-        mpsc::channel::<crate::screen_history::HistoryFrame>(8);
+    // Capture tunables, shared with the capture thread so a server push (cadence,
+    // quality, or the kill switch) applies on its next tick without a restart.
+    // Seeded from the cached copy so policy survives restarts and offline periods.
+    let history_settings = Arc::new(Mutex::new(
+        shared_cfg
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .recall_settings
+            .unwrap_or_default(),
+    ));
+    // Depth is generous only so a brief stall in the spool writer can't make the
+    // capture thread drop a keyframe; the writer just appends to disk, so it drains
+    // far faster than the 6–20s capture cadence produces.
+    let (history_tx, history_rx) = mpsc::channel::<crate::screen_history::HistoryFrame>(64);
     let mut history_enabled = {
         shared_cfg
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .screen_history_enabled
+    };
+    // Woken by the spool writer so a freshly captured frame ships immediately
+    // rather than waiting for the session's next poll tick.
+    let history_notify = Arc::new(tokio::sync::Notify::new());
+    let history_spool = if history_enabled {
+        match crate::screen_spool::Spool::new(
+            crate::config::screen_spool_dir(),
+            crate::screen_spool::DEFAULT_MAX_BYTES,
+        ) {
+            Ok(s) => Some(Arc::new(s)),
+            Err(e) => {
+                warn!("Screen history spool unavailable; disabling Recall capture: {e}");
+                history_enabled = false;
+                None
+            }
+        }
+    } else {
+        None
     };
     if history_enabled {
         let stop = Arc::new(AtomicBool::new(false));
@@ -200,7 +256,7 @@ pub async fn run_agent_loop(
             stop,
             history_active.clone(),
             history_last_input.clone(),
-            crate::screen_history::HistorySettings::default(),
+            history_settings.clone(),
         ) {
             Ok(()) => info!("Screen history ('Recall') capture enabled."),
             Err(e) => {
@@ -209,6 +265,31 @@ pub async fn run_agent_loop(
             }
         }
     }
+    if history_enabled {
+        // Drain capture → disk on a dedicated thread. This runs for the process
+        // lifetime, independent of any session, so frames captured while offline
+        // are persisted rather than dropped. Blocking file IO stays off the reactor.
+        if let Some(spool) = history_spool.clone() {
+            let notify = history_notify.clone();
+            let mut rx = history_rx;
+            if let Err(e) = std::thread::Builder::new()
+                .name("screen-spool".into())
+                .spawn(move || {
+                    while let Some(frame) = rx.blocking_recv() {
+                        match spool.push(&frame) {
+                            Ok(_) => notify.notify_one(),
+                            Err(e) => warn!("Screen history: failed to spool keyframe: {e}"),
+                        }
+                    }
+                    info!("Screen history: capture channel closed; spool writer exiting.");
+                })
+            {
+                warn!("Failed to spawn screen-spool thread; disabling Recall capture: {e}");
+                history_enabled = false;
+            }
+        }
+    }
+    let history_enabled = history_enabled && history_spool.is_some();
 
     loop {
         // Snapshot current config (clears the "changed" flag too)
@@ -433,9 +514,11 @@ pub async fn run_agent_loop(
                             key_rx: &mut key_rx,
                             capture_stop: &mut capture_stop,
                             audio_stop: &mut audio_stop,
-                            history_rx: &mut history_rx,
+                            history_spool: history_spool.clone(),
+                            history_notify: history_notify.clone(),
                             history_active: history_active.clone(),
                             history_last_input: history_last_input.clone(),
+                            history_settings: history_settings.clone(),
                             history_enabled,
                             shared_cfg: shared_cfg.clone(),
                             config_tx: config_tx.clone(),
@@ -489,6 +572,118 @@ pub async fn run_agent_loop(
     }
 }
 
+/// Ship spooled keyframes to the server, up to [`HISTORY_MAX_IN_FLIGHT`] unacked.
+///
+/// Frames stay on disk until the server acks them, so this is safe to call as often
+/// as we like: it re-sends anything whose ack timed out and skips anything already
+/// on the wire. Unparseable spool files (truncated by a crash, or written by an older
+/// agent) are dropped here rather than blocking the queue forever.
+async fn pump_history_spool(
+    spool: &crate::screen_spool::Spool,
+    out_tx: &mpsc::Sender<Message>,
+    in_flight: &mut HashMap<String, InFlightFrame>,
+) -> Result<()> {
+    // Expire stale sends so a lost ack retries instead of wedging the queue.
+    in_flight.retain(|_, f| f.sent_at.elapsed() < HISTORY_ACK_TIMEOUT);
+    if in_flight.len() >= HISTORY_MAX_IN_FLIGHT {
+        return Ok(());
+    }
+
+    let busy: std::collections::HashSet<PathBuf> =
+        in_flight.values().map(|f| f.path.clone()).collect();
+    // Scan deeper than the in-flight budget so frames already on the wire don't
+    // hide the ones behind them.
+    for path in spool.pending(HISTORY_MAX_IN_FLIGHT * 8) {
+        if in_flight.len() >= HISTORY_MAX_IN_FLIGHT {
+            break;
+        }
+        if busy.contains(&path) {
+            continue;
+        }
+        let frame = match crate::screen_spool::Spool::load(&path) {
+            Ok(f) => f,
+            Err(e) => {
+                warn!("Screen history: dropping unreadable spool frame: {e:#}");
+                crate::screen_spool::Spool::remove(&path);
+                continue;
+            }
+        };
+        let h = &frame.header;
+        // Binary, not base64-in-JSON: base64 inflated every keyframe by ~33% on a
+        // socket shared with live telemetry, and the encode/parse cost was paid on
+        // both ends for bytes that were already binary. Wire format is
+        // `HST\0` + u32 LE header length + header JSON + raw JPEG.
+        let header = serde_json::json!({
+            // Echoed back in the ack, and the server's dedup key so a retry after a
+            // lost ack cannot insert the same keyframe twice.
+            "uid"        : h.uid,
+            "captured_at": h.captured_at,
+            "monitor"    : h.monitor,
+            "w"          : h.w,
+            "h"          : h.h,
+            // u64 as string: JSON numbers lose precision past 2^53.
+            "phash"      : h.phash,
+            "ocr_text"   : h.ocr_text,
+            // Per-word boxes: what lets the dashboard overlay selectable text on a
+            // replayed frame. Omitted entirely when empty to keep the header small.
+            "ocr_words"  : if h.ocr_words.is_empty() { serde_json::Value::Null }
+                           else { serde_json::to_value(&h.ocr_words)? },
+        });
+        let header_bytes = serde_json::to_vec(&header)?;
+        let mut payload =
+            Vec::with_capacity(HISTORY_FRAME_MAGIC.len() + 4 + header_bytes.len() + frame.jpeg.len());
+        payload.extend_from_slice(HISTORY_FRAME_MAGIC);
+        payload.extend_from_slice(&(header_bytes.len() as u32).to_le_bytes());
+        payload.extend_from_slice(&header_bytes);
+        payload.extend_from_slice(&frame.jpeg);
+
+        if out_tx.send(Message::Binary(payload)).await.is_err() {
+            return Err(anyhow::anyhow!(
+                "Outbound channel closed; writer task exited unexpectedly."
+            ));
+        }
+        in_flight.insert(
+            h.uid.clone(),
+            InFlightFrame {
+                path,
+                sent_at: std::time::Instant::now(),
+            },
+        );
+    }
+    Ok(())
+}
+
+/// Handle a server acknowledgement for a spooled keyframe.
+///
+/// `ok` frames are deleted from the spool. A `reject` (frame the server will never
+/// accept — oversized, corrupt base64) is also deleted: retrying it forever would
+/// wedge the queue behind a frame that can never land.
+fn handle_history_ack(
+    text: &str,
+    in_flight: &mut HashMap<String, InFlightFrame>,
+) -> bool {
+    let Ok(val) = serde_json::from_str::<serde_json::Value>(text) else {
+        return false;
+    };
+    let kind = val["type"].as_str().unwrap_or("");
+    if kind != "history_frame_ack" {
+        return false;
+    }
+    let Some(uid) = val["uid"].as_str() else {
+        return true;
+    };
+    if let Some(f) = in_flight.remove(uid) {
+        crate::screen_spool::Spool::remove(&f.path);
+        if val["rejected"].as_bool().unwrap_or(false) {
+            warn!(
+                "Screen history: server rejected keyframe {uid} ({}); dropped from spool.",
+                val["reason"].as_str().unwrap_or("no reason given")
+            );
+        }
+    }
+    true
+}
+
 /// Bundles handles for [`run_session`] so the entry point stays under Clippy's argument limit.
 struct RunSessionArgs<'a> {
     in_rx: mpsc::Receiver<Message>,
@@ -498,9 +693,11 @@ struct RunSessionArgs<'a> {
     key_rx: &'a mut mpsc::Receiver<InputEvent>,
     capture_stop: &'a mut Option<Arc<AtomicBool>>,
     audio_stop: &'a mut Option<Arc<AtomicBool>>,
-    history_rx: &'a mut mpsc::Receiver<crate::screen_history::HistoryFrame>,
+    history_spool: Option<Arc<crate::screen_spool::Spool>>,
+    history_notify: Arc<tokio::sync::Notify>,
     history_active: Arc<AtomicBool>,
     history_last_input: Arc<AtomicU64>,
+    history_settings: Arc<Mutex<crate::screen_history::HistorySettings>>,
     history_enabled: bool,
     shared_cfg: Arc<Mutex<Config>>,
     config_tx: tokio::sync::watch::Sender<Option<Config>>,
@@ -517,9 +714,11 @@ async fn run_session(args: RunSessionArgs<'_>) -> Result<()> {
         key_rx,
         capture_stop,
         audio_stop,
-        history_rx,
+        history_spool,
+        history_notify,
         history_active,
         history_last_input,
+        history_settings,
         history_enabled,
         shared_cfg,
         config_tx,
@@ -642,6 +841,13 @@ async fn run_session(args: RunSessionArgs<'_>) -> Result<()> {
     let mut active_user: Option<String> = crate::platform::system_info::active_username()
         .or_else(crate::platform::system_info::env_username_fallback);
 
+    // Screen-history keyframes handed to the server but not yet acked, keyed by the
+    // spool uid. Dropped wholesale when the session ends, so anything unacked is
+    // simply re-sent next session (the server dedupes on uid).
+    let mut history_in_flight: HashMap<String, InFlightFrame> = HashMap::new();
+    let mut history_ticker = interval(Duration::from_secs(HISTORY_PUMP_INTERVAL_SECS));
+    history_ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
     // Event loop.
     let result: Result<()> = loop {
         tokio::select! {
@@ -651,6 +857,15 @@ async fn run_session(args: RunSessionArgs<'_>) -> Result<()> {
             msg = in_rx.recv() => {
                 match msg {
                     Some(Message::Text(text)) => {
+                        // Keyframe acks are session bookkeeping, not a server command:
+                        // consume them here and nudge the pump so the next frame ships
+                        // right away instead of waiting for the tick.
+                        if text.contains("history_frame_ack")
+                            && handle_history_ack(&text, &mut history_in_flight)
+                        {
+                            history_notify.notify_one();
+                            continue;
+                        }
                         crate::server_command::handle_server_command(crate::server_command::ServerCommandArgs {
                             text: &text,
                             frame_tx,
@@ -661,6 +876,7 @@ async fn run_session(args: RunSessionArgs<'_>) -> Result<()> {
                             config_tx: &config_tx,
                             out_tx: out_tx.clone(),
                             shared_rules: &shared_rules,
+                            history_settings: &history_settings,
                         });
                     }
                     Some(_) => {}
@@ -720,30 +936,24 @@ async fn run_session(args: RunSessionArgs<'_>) -> Result<()> {
                 }
             }
 
-            // Branch 3b: screen-history keyframes (Recall). Gated on
-            // `history_enabled` so a disabled/failed pipeline never polls a
-            // closed channel. Sent as their own JSON message (base64 JPEG +
-            // metadata), bypassing the batch buffer to avoid bloating it.
-            hf = history_rx.recv(), if history_enabled => {
-                if let Some(frame) = hf {
-                    let ev = serde_json::json!({
-                        "type"       : "history_frame",
-                        "captured_at": frame.captured_at.to_rfc3339(),
-                        "monitor"    : frame.monitor,
-                        "w"          : frame.width,
-                        "h"          : frame.height,
-                        // u64 as string: JSON numbers lose precision past 2^53.
-                        "phash"      : frame.phash.to_string(),
-                        "jpeg_b64"   : base64::engine::general_purpose::STANDARD.encode(&frame.jpeg),
-                        "ocr_text"   : frame.ocr_text,
-                    });
-                    if out_tx.send(Message::Text(ev.to_string())).await.is_err() {
-                        break Err(anyhow::anyhow!(
-                            "Outbound channel closed; writer task exited unexpectedly."
-                        ));
-                    }
+            // Branch 3b: ship spooled screen-history keyframes (Recall). Woken by
+            // the spool writer on each new capture; the ticker below covers
+            // backlog drain on reconnect and ack-timeout retries. Frames are sent
+            // as their own JSON message (base64 JPEG + metadata), bypassing the
+            // batch buffer to avoid bloating it, and are deleted from the spool
+            // only once the server acks them.
+            () = history_notify.notified(), if history_enabled => {
+                if let Some(spool) = history_spool.as_deref() {
+                    pump_history_spool(spool, &out_tx, &mut history_in_flight).await?;
                 }
-                // None => capture thread ended; keep the session alive.
+            }
+
+            // Branch 3c: periodic spool drain — catches the reconnect backlog and
+            // re-sends frames whose ack never arrived.
+            _ = history_ticker.tick(), if history_enabled => {
+                if let Some(spool) = history_spool.as_deref() {
+                    pump_history_spool(spool, &out_tx, &mut history_in_flight).await?;
+                }
             }
 
             // Branch 3: active browser URL.

--- a/agent/src/capture.rs
+++ b/agent/src/capture.rs
@@ -31,6 +31,12 @@ pub struct CaptureSettings {
     /// Which monitor to capture (0-based index into [`list_monitors`] order).
     /// `None` captures the primary monitor.
     pub monitor: Option<usize>,
+    /// When true (SYSTEM capture worker on Windows), the capture thread attaches
+    /// to whichever desktop currently owns input and re-attaches when it changes
+    /// (Default ↔ Winlogon), so the lock/sign-in screen is captured too. Ignored
+    /// off Windows and left `false` for the ordinary user-session agent, which
+    /// keeps the original single-thread behaviour.
+    pub follow_input_desktop: bool,
 }
 
 impl Default for CaptureSettings {
@@ -39,6 +45,7 @@ impl Default for CaptureSettings {
             jpeg_quality: 40,
             interval_ms: 200,
             monitor: None,
+            follow_input_desktop: false,
         }
     }
 }
@@ -86,6 +93,9 @@ impl CaptureSettings {
             jpeg_quality,
             interval_ms,
             monitor,
+            // Server-driven starts never set this; the SYSTEM capture worker
+            // enables it explicitly before calling `start_capture`.
+            follow_input_desktop: false,
         }
     }
 }
@@ -131,73 +141,162 @@ pub fn start_capture(
     std::thread::Builder::new()
         .name("screen-capture".into())
         .spawn(move || {
-            let monitors = Monitor::all().unwrap_or_default();
-            // Resolve which monitor to capture: an explicit (valid) selection,
-            // else the primary monitor, else the first available one.
-            let idx = settings
-                .monitor
-                .filter(|&i| i < monitors.len())
-                .or_else(|| monitors.iter().position(|m| m.is_primary().unwrap_or(false)))
-                .or(if monitors.is_empty() { None } else { Some(0) });
-            let Some(idx) = idx else {
-                error!("Screen capture: no monitor found.");
+            if !settings.follow_input_desktop {
+                // Ordinary path (standalone / user-session agent): one capture pass,
+                // no desktop attaching. Identical behaviour to before.
+                capture_pass(&tx, &stop, &settings, jpeg_quality, interval_ms, None);
                 return;
-            };
-            let Some(monitor) = monitors.into_iter().nth(idx) else {
-                error!("Screen capture: monitor index {idx} unavailable.");
-                return;
-            };
+            }
 
-            info!(
-                "Screen capture started: {}×{} (jpeg_q={jpeg_quality}, interval_ms={interval_ms})",
-                monitor.width().unwrap_or(0),
-                monitor.height().unwrap_or(0),
-            );
-
-            // Reuse one buffer per frame to avoid allocator churn on the capture thread.
-            let mut jpeg_data: Vec<u8> = Vec::new();
-
+            // SYSTEM capture worker: follow the input desktop. Attaching must happen
+            // on a thread that has not yet created any windows (`SetThreadDesktop`
+            // rejects a thread that owns UI objects), and xcap builds per-desktop
+            // GPU/DXGI state — so each desktop generation runs a *fresh* capture pass
+            // that exits when the input desktop switches (lock/unlock/UAC), after
+            // which we re-attach and start a new pass.
+            #[cfg(target_os = "windows")]
             loop {
-                // Check stop flag first so we exit promptly.
                 if stop.load(Ordering::Relaxed) {
                     info!("Screen capture stopped on demand.");
                     break;
                 }
-
-                match monitor.capture_image() {
-                    Ok(rgba_img) => {
-                        let rgb = image::DynamicImage::ImageRgba8(rgba_img).into_rgb8();
-
-                        jpeg_data.clear();
-                        let encoder = JpegEncoder::new_with_quality(&mut jpeg_data, jpeg_quality);
-
-                        match encoder.write_image(
-                            rgb.as_raw(),
-                            rgb.width(),
-                            rgb.height(),
-                            ExtendedColorType::Rgb8,
-                        ) {
-                            Err(e) => warn!("JPEG encode error (skipping): {e}"),
-                            Ok(()) => match tx.try_send(std::mem::take(&mut jpeg_data)) {
-                                Ok(()) => {}
-                                Err(TrySendError::Full(v)) => {
-                                    // Consumer busy – drop stale frame; keep capacity for next encode.
-                                    jpeg_data = v;
-                                }
-                                Err(TrySendError::Closed(_)) => {
-                                    info!("Frame channel closed; stopping capture.");
-                                    break;
-                                }
-                            },
-                        }
+                match crate::secure_desktop::attach_current_thread_to_input_desktop() {
+                    Ok(attachment) => {
+                        info!("Capture attached to input desktop '{}'.", attachment.name());
+                        capture_pass(
+                            &tx,
+                            &stop,
+                            &settings,
+                            jpeg_quality,
+                            interval_ms,
+                            Some(attachment.name()),
+                        );
+                        // Drop the attachment (closes the desktop handle) before the
+                        // next OpenInputDesktop/SetThreadDesktop attaches the new one.
+                        drop(attachment);
+                        // Settle briefly so a pass that returns instantly (e.g. no
+                        // monitor mid-transition) can't busy-spin the re-attach loop.
+                        std::thread::sleep(Duration::from_millis(200));
                     }
-                    Err(e) => warn!("Screen capture error (skipping): {e}"),
+                    Err(e) => {
+                        // No reachable input desktop right now (transient during
+                        // session transitions). Back off and retry.
+                        warn!("Capture: cannot attach to input desktop yet: {e:#}");
+                        std::thread::sleep(Duration::from_millis(500));
+                    }
                 }
-
-                std::thread::sleep(Duration::from_millis(interval_ms));
             }
+
+            #[cfg(not(target_os = "windows"))]
+            capture_pass(&tx, &stop, &settings, jpeg_quality, interval_ms, None);
         })
         .map_err(|e| anyhow::anyhow!("Failed to spawn capture thread: {e}"))?;
 
     Ok(())
+}
+
+/// Capture/encode/send frames until `stop` is set, the frame channel closes, or
+/// (when `watch_desktop` is `Some`) the input desktop changes away from that name.
+///
+/// Returning on a desktop change lets the caller re-attach a fresh thread to the
+/// new desktop. On other paths this simply runs until told to stop.
+fn capture_pass(
+    tx: &mpsc::Sender<Vec<u8>>,
+    stop: &Arc<AtomicBool>,
+    settings: &CaptureSettings,
+    jpeg_quality: u8,
+    interval_ms: u64,
+    watch_desktop: Option<&str>,
+) {
+    let monitors = Monitor::all().unwrap_or_default();
+    // Resolve which monitor to capture: an explicit (valid) selection,
+    // else the primary monitor, else the first available one.
+    let idx = settings
+        .monitor
+        .filter(|&i| i < monitors.len())
+        .or_else(|| monitors.iter().position(|m| m.is_primary().unwrap_or(false)))
+        .or(if monitors.is_empty() { None } else { Some(0) });
+    let Some(idx) = idx else {
+        // With no monitor we can't capture this generation. When following the
+        // input desktop this is transient (e.g. mid-switch); return so the caller
+        // re-attaches rather than spinning here.
+        if watch_desktop.is_none() {
+            error!("Screen capture: no monitor found.");
+        }
+        return;
+    };
+    let Some(monitor) = monitors.into_iter().nth(idx) else {
+        error!("Screen capture: monitor index {idx} unavailable.");
+        return;
+    };
+
+    info!(
+        "Screen capture pass: {}×{} (jpeg_q={jpeg_quality}, interval_ms={interval_ms})",
+        monitor.width().unwrap_or(0),
+        monitor.height().unwrap_or(0),
+    );
+
+    // Reuse one buffer per frame to avoid allocator churn on the capture thread.
+    let mut jpeg_data: Vec<u8> = Vec::new();
+    // Poll the input-desktop name at most a few times a second, not every frame.
+    #[cfg(target_os = "windows")]
+    let mut desktop_check = std::time::Instant::now();
+    #[cfg(not(target_os = "windows"))]
+    let _ = watch_desktop;
+
+    loop {
+        // Check stop flag first so we exit promptly.
+        if stop.load(Ordering::Relaxed) {
+            info!("Screen capture stopped on demand.");
+            break;
+        }
+
+        // Detect a desktop switch (Default ↔ Winlogon) so the caller re-attaches.
+        #[cfg(target_os = "windows")]
+        if let Some(expected) = watch_desktop {
+            if desktop_check.elapsed() >= Duration::from_millis(400) {
+                desktop_check = std::time::Instant::now();
+                if let Some(current) = crate::secure_desktop::input_desktop_name() {
+                    if current != expected {
+                        info!(
+                            "Input desktop changed '{expected}' → '{current}'; re-attaching capture."
+                        );
+                        break;
+                    }
+                }
+            }
+        }
+
+        match monitor.capture_image() {
+            Ok(rgba_img) => {
+                let rgb = image::DynamicImage::ImageRgba8(rgba_img).into_rgb8();
+
+                jpeg_data.clear();
+                let encoder = JpegEncoder::new_with_quality(&mut jpeg_data, jpeg_quality);
+
+                match encoder.write_image(
+                    rgb.as_raw(),
+                    rgb.width(),
+                    rgb.height(),
+                    ExtendedColorType::Rgb8,
+                ) {
+                    Err(e) => warn!("JPEG encode error (skipping): {e}"),
+                    Ok(()) => match tx.try_send(std::mem::take(&mut jpeg_data)) {
+                        Ok(()) => {}
+                        Err(TrySendError::Full(v)) => {
+                            // Consumer busy – drop stale frame; keep capacity for next encode.
+                            jpeg_data = v;
+                        }
+                        Err(TrySendError::Closed(_)) => {
+                            info!("Frame channel closed; stopping capture.");
+                            break;
+                        }
+                    },
+                }
+            }
+            Err(e) => warn!("Screen capture error (skipping): {e}"),
+        }
+
+        std::thread::sleep(Duration::from_millis(interval_ms));
+    }
 }

--- a/agent/src/capture_worker.rs
+++ b/agent/src/capture_worker.rs
@@ -1,0 +1,217 @@
+//! SYSTEM capture worker (Windows).
+//!
+//! Launched by the Session 0 service as **LocalSystem** into the active console
+//! session (`--capture-worker`). It exists precisely to solve the lock-screen
+//! gap: the ordinary user-session companion is pinned to the `Default` desktop
+//! with the user's token and can neither see nor drive the secure `Winlogon`
+//! desktop, and before anyone signs in there is no user token at all — so the
+//! companion isn't even running yet. This worker, being SYSTEM in the console
+//! session, is present from the sign-in screen onward and re-attaches its
+//! capture and input threads to whichever desktop currently owns input.
+//!
+//! Wiring: it is just another client of the service's `AGENT_IPC` pipe. It
+//! receives the same server-command broadcast as the companion, but acts only on
+//! `start_capture` / `stop_capture` and remote-input commands; screen frames go
+//! back to the service (and on to the dashboard) as `WsBinaryB64` IPC lines. The
+//! companion suppresses those same commands (see [`crate::role`]) so exactly one
+//! process captures each monitor.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::windows::named_pipe::ClientOptions;
+use tokio::sync::mpsc;
+use tracing::{info, warn};
+
+use crate::capture::CaptureSettings;
+use crate::input::InputController;
+
+/// Frame queue between the capture thread and the pipe writer. Small on purpose:
+/// capture drops stale frames when full, keeping the live view low-latency.
+const FRAME_QUEUE: usize = 2;
+
+/// Entry point for `--capture-worker`. Never returns under normal operation; it
+/// reconnects to the service pipe forever (the service kills this process by
+/// image name on stop / update).
+pub fn run() {
+    let rt = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            warn!("Capture worker: failed to build runtime: {e}");
+            return;
+        }
+    };
+
+    rt.block_on(async {
+        // Dedicated OS thread for input injection: SendInput targets the desktop
+        // its calling thread is attached to, so injection must run on a thread
+        // that follows the input desktop — not a shared async worker.
+        let (input_tx, input_rx) = std::sync::mpsc::channel::<String>();
+        std::thread::Builder::new()
+            .name("worker-input".into())
+            .spawn(move || input_thread(input_rx))
+            .ok();
+
+        loop {
+            if let Err(e) = run_session(&input_tx).await {
+                warn!("Capture worker session ended: {e:#}");
+            }
+            // Service may be restarting or the pipe briefly unavailable; retry.
+            tokio::time::sleep(Duration::from_millis(750)).await;
+        }
+    });
+}
+
+/// One connection to the service IPC pipe: read commands, stream frames back.
+async fn run_session(input_tx: &std::sync::mpsc::Sender<String>) -> anyhow::Result<()> {
+    let pipe = ClientOptions::new()
+        .open(crate::ipc::AGENT_IPC_PIPE_NAME)
+        .map_err(|e| anyhow::anyhow!("open agent IPC pipe: {e}"))?;
+    info!("Capture worker connected to service IPC.");
+
+    let (pipe_r, mut pipe_w) = tokio::io::split(pipe);
+    let mut reader = BufReader::new(pipe_r);
+
+    // Frames from the capture thread → base64 IPC lines on the pipe.
+    let (frame_tx, mut frame_rx) = mpsc::channel::<Vec<u8>>(FRAME_QUEUE);
+    let writer = tokio::spawn(async move {
+        while let Some(frame) = frame_rx.recv().await {
+            let line = crate::ipc::outbound_binary_line(&frame);
+            if pipe_w.write_all(line.as_bytes()).await.is_err() {
+                break;
+            }
+            if pipe_w.flush().await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // Current capture generation's stop flag (replaced on each start_capture).
+    let mut capture_stop: Option<Arc<AtomicBool>> = None;
+
+    let mut buf = Vec::new();
+    let result = loop {
+        buf.clear();
+        match reader.read_until(b'\n', &mut buf).await {
+            Ok(0) => break Ok(()), // pipe closed
+            Ok(_) => {}
+            Err(e) => break Err(anyhow::anyhow!("pipe read: {e}")),
+        }
+        while matches!(buf.last().copied(), Some(b'\n' | b'\r')) {
+            buf.pop();
+        }
+        if buf.is_empty() {
+            continue;
+        }
+
+        // Service-originated IPC frames (status/config) parse as `IpcLine`; ignore
+        // them. Anything else is a server command as raw JSON text.
+        if crate::ipc::IpcLine::from_slice(&buf).is_some() {
+            continue;
+        }
+        let Ok(text) = std::str::from_utf8(&buf) else {
+            continue;
+        };
+        let Ok(val) = serde_json::from_str::<serde_json::Value>(text) else {
+            continue;
+        };
+        let command = val.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+        match command {
+            "start_capture" => {
+                let mut settings = CaptureSettings::from_server_command(&val);
+                // The whole point of this process: follow the input desktop.
+                settings.follow_input_desktop = true;
+
+                if let Some(stop) = capture_stop.take() {
+                    stop.store(true, Ordering::Relaxed);
+                }
+                let stop = Arc::new(AtomicBool::new(false));
+                match crate::capture::start_capture(frame_tx.clone(), stop.clone(), settings) {
+                    Ok(()) => {
+                        capture_stop = Some(stop);
+                        info!(
+                            "Capture worker: streaming (jpeg_q={}, interval_ms={}).",
+                            settings.jpeg_quality, settings.interval_ms
+                        );
+                    }
+                    Err(e) => warn!("Capture worker: failed to start capture: {e:#}"),
+                }
+            }
+            "stop_capture" => {
+                if let Some(stop) = capture_stop.take() {
+                    stop.store(true, Ordering::Relaxed);
+                    info!("Capture worker: capture stopped (no viewers).");
+                }
+            }
+            // Everything else the worker cares about is remote input; hand the raw
+            // JSON to the desktop-following input thread. Non-input commands simply
+            // fail to deserialize there and are ignored.
+            _ => {
+                let _ = input_tx.send(text.to_string());
+            }
+        }
+    };
+
+    // Tear down this generation's capture before reconnecting.
+    if let Some(stop) = capture_stop.take() {
+        stop.store(true, Ordering::Relaxed);
+    }
+    drop(frame_tx);
+    let _ = writer.await;
+    result
+}
+
+/// Owns the `InputController`, re-attaching to the input desktop as it changes.
+///
+/// `SetThreadDesktop` is rejected once a thread owns windows, and `Enigo` may
+/// create a message window bound to its desktop — so on every desktop switch we
+/// drop the controller *before* re-attaching, then build a fresh one on the new
+/// desktop.
+fn input_thread(rx: std::sync::mpsc::Receiver<String>) {
+    let mut attachment: Option<crate::secure_desktop::DesktopAttachment> = None;
+    let mut controller: Option<InputController> = None;
+
+    while let Ok(json) = rx.recv() {
+        let current = crate::secure_desktop::input_desktop_name();
+        let need_reattach = match (attachment.as_ref(), current.as_ref()) {
+            (Some(a), Some(cur)) => a.name() != cur.as_str(),
+            _ => true,
+        };
+
+        if need_reattach {
+            // Drop controller first so no window keeps us bound to the old desktop.
+            controller = None;
+            attachment = None;
+            match crate::secure_desktop::attach_current_thread_to_input_desktop() {
+                Ok(a) => {
+                    info!("Capture worker: input attached to desktop '{}'.", a.name());
+                    attachment = Some(a);
+                    match InputController::new() {
+                        Ok(c) => controller = Some(c),
+                        Err(e) => {
+                            warn!("Capture worker: input controller init failed: {e:#}");
+                            continue;
+                        }
+                    }
+                }
+                Err(e) => {
+                    // No reachable input desktop this instant; drop the command.
+                    warn!("Capture worker: cannot attach input desktop: {e:#}");
+                    continue;
+                }
+            }
+        }
+
+        if let Some(ctrl) = controller.as_mut() {
+            if let Err(e) = ctrl.handle_command(&json) {
+                warn!("Capture worker: control command error: {e:#}");
+            }
+        }
+    }
+}

--- a/agent/src/config.rs
+++ b/agent/src/config.rs
@@ -93,6 +93,13 @@ pub struct Config {
     /// server-pushed per-agent disable.
     #[serde(default = "default_screen_history_enabled")]
     pub screen_history_enabled: bool,
+
+    /// Capture tunables pushed by the server (`set_recall_settings`). Cached here so
+    /// a cadence change or the operator kill switch survives restarts and keeps
+    /// applying while the agent is offline. `None` = never pushed; use built-in
+    /// defaults.
+    #[serde(default)]
+    pub recall_settings: Option<crate::screen_history::HistorySettings>,
 }
 
 /// Time window in agent-local time.
@@ -155,6 +162,7 @@ impl Default for Config {
             internet_block_rules: Vec::new(),
             app_block_rules: Vec::new(),
             screen_history_enabled: default_screen_history_enabled(),
+            recall_settings: None,
         }
     }
 }
@@ -184,6 +192,25 @@ pub fn program_data_vantyr_dir() -> PathBuf {
 #[cfg(windows)]
 pub fn updates_staging_dir() -> PathBuf {
     program_data_vantyr_dir().join("updates")
+}
+
+/// Durable spool for screen-history ("Recall") keyframes awaiting server ack.
+///
+/// Lives beside the rest of the machine-wide state so keyframes captured while
+/// the agent is disconnected survive both reconnects and agent restarts. On
+/// non-Windows builds (dev/test) it falls back to the local data dir.
+pub fn screen_spool_dir() -> PathBuf {
+    #[cfg(windows)]
+    {
+        program_data_vantyr_dir().join("recall-spool")
+    }
+    #[cfg(not(windows))]
+    {
+        dirs::data_local_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("vantyr")
+            .join("recall-spool")
+    }
 }
 
 /// Machine-wide encrypted config (Windows). Alias for [`config_path`] on Windows.

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -75,6 +75,7 @@ mod remote_script;
 mod role;
 mod schedule;
 mod screen_history;
+mod screen_spool;
 #[cfg(target_os = "windows")]
 mod secure_desktop;
 mod server_command;

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -58,6 +58,8 @@ mod app_display;
 #[cfg(target_os = "windows")]
 mod audio_capture;
 mod capture;
+#[cfg(target_os = "windows")]
+mod capture_worker;
 mod config;
 mod enrollment;
 mod input;
@@ -70,8 +72,11 @@ mod network_policy;
 mod network_scheduler;
 mod platform;
 mod remote_script;
+mod role;
 mod schedule;
 mod screen_history;
+#[cfg(target_os = "windows")]
+mod secure_desktop;
 mod server_command;
 #[cfg(target_os = "windows")]
 mod service;
@@ -205,8 +210,33 @@ fn main() {
         return;
     }
 
+    // SYSTEM capture worker: launched by the service into the console session to
+    // capture + drive the input desktop (including the lock/sign-in screen).
+    // Distinct log file, no UI, no single-instance mutex (it coexists with the
+    // user-session companion, which is the same binary).
+    #[cfg(target_os = "windows")]
+    if args.iter().any(|a| a == "--capture-worker") {
+        let _log_guard = init_logging(Some(program_data_log_path("capture-worker.log")));
+        info!(
+            "Vantyr agent v{} — capture worker (SYSTEM, session-attached).",
+            env!("CARGO_PKG_VERSION")
+        );
+        role::set_role(role::AgentRole::CaptureWorker);
+        capture_worker::run();
+        return;
+    }
+
     let _log_guard = init_logging(parse_log_file_arg(&args));
     info!("Vantyr agent v{}", env!("CARGO_PKG_VERSION"));
+
+    // Companion launched by the service into the user session: user-context
+    // telemetry only. Live capture + remote input are owned by the SYSTEM capture
+    // worker, so suppress them here (see `role`) to avoid double-capturing.
+    #[cfg(target_os = "windows")]
+    if args.iter().any(|a| a == "--service-managed") {
+        role::set_role(role::AgentRole::Companion);
+        info!("Running as service-managed companion (capture/input delegated to worker).");
+    }
 
     #[cfg(target_os = "windows")]
     enforce_single_instance();

--- a/agent/src/role.rs
+++ b/agent/src/role.rs
@@ -1,0 +1,49 @@
+//! Process role.
+//!
+//! The agent binary runs in one of three roles on Windows:
+//!
+//! * [`AgentRole::Standalone`] — the whole agent in one process (a user runs
+//!   `vantyr-agent.exe` directly, no service). Captures + injects input in-process.
+//! * [`AgentRole::Companion`] — launched by the Session 0 service into the
+//!   interactive **user** session (`--service-managed`). Owns user-context
+//!   telemetry (keystrokes, URLs, window focus, screen history) but **not** live
+//!   screen capture or remote input: those belong to the capture worker, which
+//!   can also reach the secure/lock-screen desktop. Suppressing them here avoids
+//!   two processes capturing the same monitor.
+//! * [`AgentRole::CaptureWorker`] — launched by the service as **SYSTEM** into
+//!   the active console session (`--capture-worker`). Does live capture + remote
+//!   input only, re-attaching to whichever desktop currently owns input
+//!   (`Default` when signed in, `Winlogon` at the lock screen). See
+//!   [`crate::capture_worker`].
+//!
+//! On Linux only [`AgentRole::Standalone`] is ever used.
+
+use std::sync::atomic::{AtomicU8, Ordering};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AgentRole {
+    Standalone = 0,
+    Companion = 1,
+    CaptureWorker = 2,
+}
+
+static ROLE: AtomicU8 = AtomicU8::new(AgentRole::Standalone as u8);
+
+pub fn set_role(role: AgentRole) {
+    ROLE.store(role as u8, Ordering::Relaxed);
+}
+
+pub fn role() -> AgentRole {
+    match ROLE.load(Ordering::Relaxed) {
+        1 => AgentRole::Companion,
+        2 => AgentRole::CaptureWorker,
+        _ => AgentRole::Standalone,
+    }
+}
+
+/// True when this process must NOT run live screen capture or remote input,
+/// because a sibling capture worker owns them. Only the [`AgentRole::Companion`]
+/// suppresses them; standalone and the worker itself run them normally.
+pub fn suppresses_capture_and_input() -> bool {
+    role() == AgentRole::Companion
+}

--- a/agent/src/screen_history.rs
+++ b/agent/src/screen_history.rs
@@ -13,7 +13,7 @@
 
 use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
-    Arc,
+    Arc, Mutex,
 };
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -27,10 +27,20 @@ use xcap::Monitor;
 
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Tunables for the history-capture loop. Parsed from a server policy push in a
-/// later phase; sensible fleet-friendly defaults here.
-#[derive(Clone, Copy, Debug)]
+/// Tunables for the history-capture loop.
+///
+/// Pushed by the server (`set_recall_settings`) and cached in agent config, so a
+/// cadence change or the kill switch survives restarts and applies while offline.
+/// The values here are the fallback for an agent that has never received a push.
+///
+/// `#[serde(default)]` on the struct means a push omitting a field leaves it at the
+/// default rather than failing to parse the whole message.
+#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
 pub struct HistorySettings {
+    /// Operator kill switch. When false the capture loop keeps running but records
+    /// nothing, so re-enabling takes effect immediately without a restart.
+    pub enabled: bool,
     /// Normal cadence (ms) while the user is active but not actively interacting
     /// (e.g. reading, watching). Adaptive capture slows to this when input is quiet.
     pub interval_ms: u64,
@@ -50,8 +60,10 @@ pub struct HistorySettings {
     /// Force a keyframe at least this often even if the screen looks unchanged,
     /// so the timelapse has coverage and "machine was on" is provable.
     pub keyframe_max_gap_ms: u64,
-    /// Which monitor to capture (index into [`crate::capture::list_monitors`]);
-    /// `None` = primary.
+    /// Which monitor to capture (index into [`crate::capture::list_monitors`]).
+    /// `None` = **every** monitor, each deduped independently — a second screen is
+    /// usually where the reference material, chat, or docs live, and recording only
+    /// the primary leaves the timeline showing half of what the person was doing.
     pub monitor: Option<usize>,
     /// Run on-device OCR on each stored frame.
     pub ocr: bool,
@@ -60,6 +72,7 @@ pub struct HistorySettings {
 impl Default for HistorySettings {
     fn default() -> Self {
         Self {
+            enabled: true,
             interval_ms: 20_000,
             hot_interval_ms: 6_000,
             hot_idle_ms: 20_000,
@@ -88,6 +101,9 @@ pub struct HistoryFrame {
     pub phash: u64,
     /// On-device OCR text, if OCR ran and produced anything.
     pub ocr_text: Option<String>,
+    /// Per-word bounding boxes for that text, normalized to 0..1 of this frame.
+    /// Empty when OCR is off or found nothing.
+    pub ocr_words: Vec<OcrWord>,
 }
 
 // ── Image helpers ─────────────────────────────────────────────────────────────
@@ -150,11 +166,42 @@ fn encode_jpeg(img: &RgbaImage, quality: u8) -> anyhow::Result<Vec<u8>> {
 
 // ── On-device OCR ─────────────────────────────────────────────────────────────
 
+/// One OCR'd word and where it sits on the frame.
+///
+/// Coordinates are normalized to 0..1 of the stored frame, so the dashboard can
+/// position them over the replayed image at any rendered size without knowing the
+/// capture resolution.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct OcrWord {
+    /// The word text.
+    pub t: String,
+    pub x: f32,
+    pub y: f32,
+    pub w: f32,
+    pub h: f32,
+}
+
+/// Cap on stored word boxes per frame. A dense page of text runs to a few hundred
+/// words; this bounds the payload for pathological screens (a wall of logs) without
+/// truncating anything realistic.
+const MAX_OCR_WORDS: usize = 1_500;
+
+/// Text plus per-word geometry from one frame.
+#[derive(Debug, Clone, Default)]
+pub struct OcrOutput {
+    pub text: String,
+    pub words: Vec<OcrWord>,
+}
+
 /// Extract text from a frame using the OS OCR engine. Windows uses the native
 /// `Windows.Media.Ocr` engine (no model download, runs offline). Other platforms
-/// return `None` for now (Phase 2 can wire Tesseract on Linux).
+/// return empty output for now (a later phase can wire Tesseract on Linux).
+///
+/// Word geometry is kept, not just the concatenated text: it is what lets the
+/// dashboard lay invisible selectable spans over a replayed frame, so text on a
+/// screen from three weeks ago can be selected and copied like a normal web page.
 #[cfg(windows)]
-fn ocr_rgba(img: &RgbaImage) -> anyhow::Result<String> {
+fn ocr_rgba(img: &RgbaImage) -> anyhow::Result<OcrOutput> {
     use windows::{
         Graphics::Imaging::{BitmapPixelFormat, SoftwareBitmap},
         Media::Ocr::OcrEngine,
@@ -163,7 +210,7 @@ fn ocr_rgba(img: &RgbaImage) -> anyhow::Result<String> {
 
     let (w, h) = (img.width(), img.height());
     if w == 0 || h == 0 {
-        return Ok(String::new());
+        return Ok(OcrOutput::default());
     }
 
     // Windows OCR wants BGRA8; `image` gives us RGBA8. Swizzle in place.
@@ -203,12 +250,40 @@ fn ocr_rgba(img: &RgbaImage) -> anyhow::Result<String> {
         std::thread::sleep(Duration::from_millis(2)); // Started — keep waiting
     }
     let result = op.GetResults()?;
-    Ok(result.Text()?.to_string())
+
+    // Walk lines → words to keep each word's bounding box. `OcrResult::Text()` gives
+    // only the flattened string, which is enough to search but not to point at.
+    let (fw, fh) = (w as f32, h as f32);
+    let mut words: Vec<OcrWord> = Vec::new();
+    'outer: for line in result.Lines()? {
+        for word in line.Words()? {
+            if words.len() >= MAX_OCR_WORDS {
+                break 'outer;
+            }
+            let text = word.Text()?.to_string();
+            if text.trim().is_empty() {
+                continue;
+            }
+            let r = word.BoundingRect()?;
+            words.push(OcrWord {
+                t: text,
+                x: r.X / fw,
+                y: r.Y / fh,
+                w: r.Width / fw,
+                h: r.Height / fh,
+            });
+        }
+    }
+
+    Ok(OcrOutput {
+        text: result.Text()?.to_string(),
+        words,
+    })
 }
 
 #[cfg(not(windows))]
-fn ocr_rgba(_img: &RgbaImage) -> anyhow::Result<String> {
-    Ok(String::new())
+fn ocr_rgba(_img: &RgbaImage) -> anyhow::Result<OcrOutput> {
+    Ok(OcrOutput::default())
 }
 
 // ── Capture loop ──────────────────────────────────────────────────────────────
@@ -241,40 +316,50 @@ pub fn start_history_capture(
     stop: Arc<AtomicBool>,
     active: Arc<AtomicBool>,
     last_input_ms: Arc<AtomicU64>,
-    settings: HistorySettings,
+    settings: Arc<Mutex<HistorySettings>>,
 ) -> anyhow::Result<()> {
     // Short quantum so cadence changes (and stop) take effect quickly; the desired
     // interval is re-evaluated every tick from the current activity level.
     let quantum_ms: u64 = 1_000;
     let quantum = Duration::from_millis(quantum_ms);
-    let quality = settings.jpeg_quality.clamp(1, 100);
+    // Snapshot for the one-time monitor selection + startup log. Everything inside
+    // the loop re-reads, so a server push changes behaviour without a restart.
+    let initial = *settings.lock().unwrap_or_else(|e| e.into_inner());
 
     std::thread::Builder::new()
         .name("screen-history".into())
         .spawn(move || {
-            let monitors = Monitor::all().unwrap_or_default();
-            let idx = settings
-                .monitor
-                .filter(|&i| i < monitors.len())
-                .or_else(|| monitors.iter().position(|m| m.is_primary().unwrap_or(false)))
-                .or(if monitors.is_empty() { None } else { Some(0) });
-            let Some(idx) = idx else {
+            let all = Monitor::all().unwrap_or_default();
+            if all.is_empty() {
                 error!("Screen history: no monitor found; capture disabled.");
                 return;
+            }
+            // Either the one configured monitor, or all of them.
+            let targets: Vec<(usize, Monitor)> = match initial.monitor {
+                Some(i) if i < all.len() => {
+                    all.into_iter().enumerate().filter(|(j, _)| *j == i).collect()
+                }
+                Some(i) => {
+                    warn!("Screen history: monitor index {i} unavailable; capturing all.");
+                    all.into_iter().enumerate().collect()
+                }
+                None => all.into_iter().enumerate().collect(),
             };
-            let Some(monitor) = monitors.into_iter().nth(idx) else {
-                error!("Screen history: monitor index {idx} unavailable.");
+            if targets.is_empty() {
+                error!("Screen history: no capturable monitor; capture disabled.");
                 return;
-            };
+            }
 
             info!(
-                "Screen history capture started on monitor {idx} (interval={}ms, q={quality}, max_dim={}, ocr={})",
-                settings.interval_ms, settings.max_dim, settings.ocr
+                "Screen history capture started on {} monitor(s) (interval={}ms, q={}, max_dim={}, ocr={})",
+                targets.len(), initial.interval_ms, initial.jpeg_quality, initial.max_dim, initial.ocr
             );
 
-            let mut last_hash: Option<u64> = None;
+            // Dedup state is per-monitor: a still second screen must not suppress
+            // keyframes from the primary one the person is actually working on.
+            let mut last_hash: Vec<Option<u64>> = vec![None; targets.len()];
             // ms since a frame was last *stored*, to enforce keyframe_max_gap_ms.
-            let mut since_stored_ms: u64 = settings.keyframe_max_gap_ms; // force first frame
+            let mut since_stored_ms: u64 = initial.keyframe_max_gap_ms; // force first frame
             // ms accumulated toward the current (adaptive) desired interval.
             let mut waited_ms: u64 = 0;
 
@@ -287,6 +372,17 @@ pub fn start_history_capture(
                 since_stored_ms = since_stored_ms.saturating_add(quantum_ms);
                 waited_ms = waited_ms.saturating_add(quantum_ms);
 
+                // Re-read settings each tick so a server push (cadence, quality, or
+                // the kill switch) applies without restarting the agent.
+                let cfg = *settings.lock().unwrap_or_else(|e| e.into_inner());
+
+                if !cfg.enabled {
+                    // Operator kill switch. Keep the loop alive so re-enabling is
+                    // immediate, but record nothing.
+                    waited_ms = 0;
+                    continue;
+                }
+
                 if !active.load(Ordering::Relaxed) {
                     // AFK — capture nothing; reset the accumulator so returning from
                     // idle doesn't immediately fire a frame before real interaction.
@@ -296,83 +392,100 @@ pub fn start_history_capture(
 
                 // Adaptive cadence: fast while actively interacting, normal when quiet.
                 let idle_ms = now_ms().saturating_sub(last_input_ms.load(Ordering::Relaxed));
-                let desired_ms = if idle_ms <= settings.hot_idle_ms {
-                    settings.hot_interval_ms
+                let desired_ms = if idle_ms <= cfg.hot_idle_ms {
+                    cfg.hot_interval_ms
                 } else {
-                    settings.interval_ms
+                    cfg.interval_ms
                 };
-                let force_keyframe = since_stored_ms >= settings.keyframe_max_gap_ms;
+                let force_keyframe = since_stored_ms >= cfg.keyframe_max_gap_ms;
                 if waited_ms < desired_ms.max(quantum_ms) && !force_keyframe {
                     continue;
                 }
                 waited_ms = 0;
 
-                let rgba = match monitor.capture_image() {
-                    Ok(img) => img,
-                    Err(e) => {
-                        warn!("Screen history capture error (skipping): {e}");
-                        continue;
-                    }
-                };
+                // Any monitor storing a frame this tick resets the keyframe-gap
+                // heartbeat: the point of that heartbeat is "prove the machine was
+                // on", which one screen answers for all of them.
+                let mut stored_any = false;
+                let mut closed = false;
 
-                let small = downscale(rgba, settings.max_dim);
-                let hash = average_hash(&small);
-
-                if !force_keyframe {
-                    if let Some(prev) = last_hash {
-                        if hamming(prev, hash) <= settings.dedup_hamming {
-                            debug!("Screen history: unchanged frame dropped (dedup).");
+                for (slot, (idx, monitor)) in targets.iter().enumerate() {
+                    let rgba = match monitor.capture_image() {
+                        Ok(img) => img,
+                        Err(e) => {
+                            warn!("Screen history capture error on monitor {idx} (skipping): {e}");
                             continue;
+                        }
+                    };
+
+                    let small = downscale(rgba, cfg.max_dim);
+                    let hash = average_hash(&small);
+
+                    if !force_keyframe {
+                        if let Some(prev) = last_hash[slot] {
+                            if hamming(prev, hash) <= cfg.dedup_hamming {
+                                debug!("Screen history: unchanged frame dropped (monitor {idx}).");
+                                continue;
+                            }
+                        }
+                    }
+
+                    let (ocr_text, ocr_words) = if cfg.ocr {
+                        match ocr_rgba(&small) {
+                            Ok(o) if !o.text.trim().is_empty() => (Some(o.text), o.words),
+                            Ok(_) => (None, Vec::new()),
+                            Err(e) => {
+                                debug!("Screen history OCR failed (continuing without text): {e}");
+                                (None, Vec::new())
+                            }
+                        }
+                    } else {
+                        (None, Vec::new())
+                    };
+
+                    let jpeg = match encode_jpeg(&small, cfg.jpeg_quality.clamp(1, 100)) {
+                        Ok(j) => j,
+                        Err(e) => {
+                            warn!("Screen history JPEG encode failed (skipping): {e}");
+                            continue;
+                        }
+                    };
+
+                    let frame = HistoryFrame {
+                        captured_at: chrono::Utc::now(),
+                        monitor: *idx,
+                        width: small.width(),
+                        height: small.height(),
+                        jpeg,
+                        phash: hash,
+                        ocr_text,
+                        ocr_words,
+                    };
+
+                    // Non-blocking send: the spool writer drains this promptly, so a
+                    // full channel means something is badly wedged — drop rather than
+                    // stall capture. Only advance dedup state on an accepted frame.
+                    match tx.try_send(frame) {
+                        Ok(()) => {
+                            last_hash[slot] = Some(hash);
+                            stored_any = true;
+                        }
+                        Err(TrySendError::Full(_)) => {
+                            debug!("Screen history: consumer busy; keyframe dropped.");
+                        }
+                        Err(TrySendError::Closed(_)) => {
+                            info!("Screen history: receiver dropped; stopping capture.");
+                            closed = true;
+                            break;
                         }
                     }
                 }
 
-                let ocr_text = if settings.ocr {
-                    match ocr_rgba(&small) {
-                        Ok(t) if !t.trim().is_empty() => Some(t),
-                        Ok(_) => None,
-                        Err(e) => {
-                            debug!("Screen history OCR failed (continuing without text): {e}");
-                            None
-                        }
-                    }
-                } else {
-                    None
-                };
-
-                let jpeg = match encode_jpeg(&small, quality) {
-                    Ok(j) => j,
-                    Err(e) => {
-                        warn!("Screen history JPEG encode failed (skipping): {e}");
-                        continue;
-                    }
-                };
-
-                let frame = HistoryFrame {
-                    captured_at: chrono::Utc::now(),
-                    monitor: idx,
-                    width: small.width(),
-                    height: small.height(),
-                    jpeg,
-                    phash: hash,
-                    ocr_text,
-                };
-
-                // Non-blocking send: while the agent is disconnected nobody drains
-                // the channel, so drop rather than wedge the capture thread. Only
-                // advance dedup/keyframe state when a frame is actually accepted.
-                match tx.try_send(frame) {
-                    Ok(()) => {
-                        last_hash = Some(hash);
-                        since_stored_ms = 0;
-                    }
-                    Err(TrySendError::Full(_)) => {
-                        debug!("Screen history: consumer busy; keyframe dropped.");
-                    }
-                    Err(TrySendError::Closed(_)) => {
-                        info!("Screen history: receiver dropped; stopping capture.");
-                        break;
-                    }
+                if closed {
+                    break;
+                }
+                if stored_any {
+                    since_stored_ms = 0;
                 }
             }
         })

--- a/agent/src/screen_spool.rs
+++ b/agent/src/screen_spool.rs
@@ -1,0 +1,321 @@
+//! Durable on-disk spool for screen-history ("Recall") keyframes.
+//!
+//! Keyframes used to go straight from the capture thread onto the session's
+//! outbound channel with a `try_send`, which meant every frame captured while the
+//! agent was disconnected — reconnect backoff, laptop asleep, server restart,
+//! VPN drop — was silently discarded. A Recall timeline with unexplained holes in
+//! it is worse than no timeline, so capture now always lands here first.
+//!
+//! The spool is the single hand-off point between capture and the session:
+//!
+//! * capture thread → [`Spool::push`] (durable, survives agent restarts)
+//! * session → [`Spool::pending`] → send → server ack → [`Spool::remove`]
+//!
+//! Frames are only removed once the server has acknowledged persisting them, so
+//! an interrupted session re-sends whatever was in flight. The server dedupes on
+//! the `uid` written here, which makes that retry idempotent.
+//!
+//! Disk use is bounded by `max_bytes`: when the spool is over budget the *oldest*
+//! frames are evicted first, degrading to "we kept the most recent N hours" rather
+//! than filling the user's disk.
+
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context as _, Result};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use crate::screen_history::HistoryFrame;
+
+/// Magic + version prefix so a truncated or foreign file is rejected cheaply.
+const MAGIC: &[u8; 4] = b"VRF1";
+/// Spool file extension.
+const EXT: &str = "vrf";
+/// Default disk budget for spooled keyframes (bytes).
+pub const DEFAULT_MAX_BYTES: u64 = 512 * 1024 * 1024;
+
+/// Metadata header stored alongside the JPEG bytes in each spool file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FrameHeader {
+    /// Client-generated id. Echoed by the server in its ack and used as the
+    /// server-side dedup key, so a re-sent frame can never double-insert.
+    pub uid: String,
+    /// RFC3339 UTC. Kept as a string because it is forwarded to the server
+    /// verbatim, and because the agent's `chrono` is built without `serde`.
+    pub captured_at: String,
+    /// Epoch-ms copy of `captured_at`, used for spool ordering without reparsing.
+    pub captured_ms: i64,
+    pub monitor: usize,
+    pub w: u32,
+    pub h: u32,
+    /// u64 aHash as a decimal string (JSON numbers lose precision past 2^53).
+    pub phash: String,
+    pub ocr_text: Option<String>,
+    /// Per-word OCR boxes (normalized 0..1). Defaulted so spool files written by an
+    /// older agent still load after an upgrade instead of being discarded.
+    #[serde(default)]
+    pub ocr_words: Vec<crate::screen_history::OcrWord>,
+}
+
+/// A spool entry read back off disk, ready to ship.
+#[derive(Debug, Clone)]
+pub struct SpooledFrame {
+    pub header: FrameHeader,
+    pub jpeg: Vec<u8>,
+}
+
+/// A bounded, durable FIFO of keyframes awaiting server acknowledgement.
+#[derive(Debug, Clone)]
+pub struct Spool {
+    dir: PathBuf,
+    max_bytes: u64,
+}
+
+impl Spool {
+    /// Open (creating if needed) the spool directory.
+    pub fn new(dir: PathBuf, max_bytes: u64) -> Result<Self> {
+        fs::create_dir_all(&dir)
+            .with_context(|| format!("creating screen spool dir {}", dir.display()))?;
+        Ok(Self { dir, max_bytes })
+    }
+
+    /// Append a captured keyframe. Returns the assigned `uid`.
+    ///
+    /// The write is atomic (temp file + rename) so a crash mid-write can never
+    /// leave a half-frame that later fails to parse. Enforcing the disk budget
+    /// afterwards means a single oversized frame is accepted and then trimmed,
+    /// rather than being rejected outright.
+    pub fn push(&self, frame: &HistoryFrame) -> Result<String> {
+        let uid = uuid::Uuid::new_v4().to_string();
+        let captured_ms = frame.captured_at.timestamp_millis();
+        let header = FrameHeader {
+            uid: uid.clone(),
+            captured_at: frame.captured_at.to_rfc3339(),
+            captured_ms,
+            monitor: frame.monitor,
+            w: frame.width,
+            h: frame.height,
+            phash: frame.phash.to_string(),
+            ocr_text: frame.ocr_text.clone(),
+            ocr_words: frame.ocr_words.clone(),
+        };
+        let header_bytes = serde_json::to_vec(&header)?;
+
+        // Filename sorts chronologically: capture order is replay order, and the
+        // uid suffix keeps two frames in the same millisecond from colliding.
+        let name = format!("{:013}-{uid}.{EXT}", captured_ms.max(0));
+        let final_path = self.dir.join(&name);
+        let tmp_path = self.dir.join(format!("{name}.tmp"));
+
+        {
+            let mut f = fs::File::create(&tmp_path)
+                .with_context(|| format!("creating {}", tmp_path.display()))?;
+            f.write_all(MAGIC)?;
+            f.write_all(&(header_bytes.len() as u32).to_le_bytes())?;
+            f.write_all(&header_bytes)?;
+            f.write_all(&frame.jpeg)?;
+            f.flush()?;
+        }
+        fs::rename(&tmp_path, &final_path).with_context(|| {
+            format!("renaming {} -> {}", tmp_path.display(), final_path.display())
+        })?;
+
+        self.enforce_budget();
+        Ok(uid)
+    }
+
+    /// Oldest-first paths of frames awaiting acknowledgement, capped at `limit`.
+    pub fn pending(&self, limit: usize) -> Vec<PathBuf> {
+        let mut paths = self.entries();
+        paths.truncate(limit);
+        paths.into_iter().map(|(p, _)| p).collect()
+    }
+
+    /// Number of frames currently spooled.
+    pub fn len(&self) -> usize {
+        self.entries().len()
+    }
+
+    /// Read one spool file back into a sendable frame.
+    pub fn load(path: &Path) -> Result<SpooledFrame> {
+        let bytes = fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+        if bytes.len() < MAGIC.len() + 4 || &bytes[..4] != MAGIC {
+            bail!("not a spool frame (bad magic): {}", path.display());
+        }
+        let hlen = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]) as usize;
+        let hstart = MAGIC.len() + 4;
+        let hend = hstart
+            .checked_add(hlen)
+            .filter(|e| *e <= bytes.len())
+            .with_context(|| format!("truncated spool frame: {}", path.display()))?;
+        let header: FrameHeader = serde_json::from_slice(&bytes[hstart..hend])
+            .with_context(|| format!("bad spool header: {}", path.display()))?;
+        Ok(SpooledFrame {
+            header,
+            jpeg: bytes[hend..].to_vec(),
+        })
+    }
+
+    /// Drop an acknowledged frame. Missing files are not an error — a duplicate
+    /// ack (or a concurrent eviction) is a benign race, not a failure.
+    pub fn remove(path: &Path) {
+        if let Err(e) = fs::remove_file(path) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                warn!("Screen spool: failed to remove {}: {e}", path.display());
+            }
+        }
+    }
+
+    /// Spool files (oldest first) with their sizes, skipping temp/foreign files.
+    fn entries(&self) -> Vec<(PathBuf, u64)> {
+        let Ok(rd) = fs::read_dir(&self.dir) else {
+            return Vec::new();
+        };
+        let mut out: Vec<(PathBuf, u64)> = rd
+            .flatten()
+            .filter_map(|e| {
+                let path = e.path();
+                if path.extension().and_then(|s| s.to_str()) != Some(EXT) {
+                    return None;
+                }
+                let len = e.metadata().ok()?.len();
+                Some((path, len))
+            })
+            .collect();
+        // Filenames are zero-padded epoch-ms, so lexical order is chronological.
+        out.sort_by(|a, b| a.0.file_name().cmp(&b.0.file_name()));
+        out
+    }
+
+    /// Evict oldest frames until the spool fits its disk budget.
+    fn enforce_budget(&self) {
+        let entries = self.entries();
+        let mut total: u64 = entries.iter().map(|(_, n)| *n).sum();
+        if total <= self.max_bytes {
+            return;
+        }
+        let mut evicted = 0u32;
+        for (path, len) in entries {
+            if total <= self.max_bytes {
+                break;
+            }
+            Self::remove(&path);
+            total = total.saturating_sub(len);
+            evicted += 1;
+        }
+        if evicted > 0 {
+            debug!("Screen spool over budget: evicted {evicted} oldest keyframe(s).");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn frame(ms: i64) -> HistoryFrame {
+        HistoryFrame {
+            captured_at: chrono::DateTime::from_timestamp_millis(ms).unwrap(),
+            monitor: 0,
+            width: 4,
+            height: 3,
+            jpeg: vec![7u8; 128],
+            phash: u64::MAX,
+            ocr_text: Some("hello".into()),
+            ocr_words: vec![crate::screen_history::OcrWord {
+                t: "hello".into(),
+                x: 0.1,
+                y: 0.2,
+                w: 0.3,
+                h: 0.05,
+            }],
+        }
+    }
+
+    #[test]
+    fn round_trips_a_frame() {
+        let dir = tempdir();
+        let spool = Spool::new(dir.clone(), DEFAULT_MAX_BYTES).unwrap();
+        let uid = spool.push(&frame(1_700_000_000_000)).unwrap();
+
+        let pending = spool.pending(10);
+        assert_eq!(pending.len(), 1);
+        let loaded = Spool::load(&pending[0]).unwrap();
+        assert_eq!(loaded.header.uid, uid);
+        // u64 phash must survive the string round-trip without precision loss.
+        assert_eq!(loaded.header.phash, u64::MAX.to_string());
+        assert_eq!(loaded.header.ocr_text.as_deref(), Some("hello"));
+        // Word geometry must survive the spool, or replayed frames lose selectable text.
+        assert_eq!(loaded.header.ocr_words.len(), 1);
+        assert_eq!(loaded.header.ocr_words[0].t, "hello");
+        assert!((loaded.header.ocr_words[0].x - 0.1).abs() < 1e-6);
+        assert_eq!(loaded.jpeg, vec![7u8; 128]);
+
+        Spool::remove(&pending[0]);
+        assert_eq!(spool.len(), 0);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pending_is_oldest_first() {
+        let dir = tempdir();
+        let spool = Spool::new(dir.clone(), DEFAULT_MAX_BYTES).unwrap();
+        // Push out of chronological order; ordering must come from captured_at.
+        spool.push(&frame(1_700_000_002_000)).unwrap();
+        spool.push(&frame(1_700_000_000_000)).unwrap();
+        spool.push(&frame(1_700_000_001_000)).unwrap();
+
+        let stamps: Vec<i64> = spool
+            .pending(10)
+            .iter()
+            .map(|p| Spool::load(p).unwrap().header.captured_ms)
+            .collect();
+        assert_eq!(
+            stamps,
+            vec![1_700_000_000_000, 1_700_000_001_000, 1_700_000_002_000]
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn evicts_oldest_when_over_budget() {
+        let dir = tempdir();
+        // Budget fits roughly two frames (~128B payload + header each).
+        let spool = Spool::new(dir.clone(), 600).unwrap();
+        for i in 0..6 {
+            spool.push(&frame(1_700_000_000_000 + i * 1000)).unwrap();
+        }
+        let remaining: Vec<i64> = spool
+            .pending(10)
+            .iter()
+            .map(|p| Spool::load(p).unwrap().header.captured_ms)
+            .collect();
+        assert!(!remaining.is_empty(), "budget must not empty the spool");
+        assert!(remaining.len() < 6, "oldest frames should have been evicted");
+        // Whatever survived must be the newest frames, still in order.
+        let mut sorted = remaining.clone();
+        sorted.sort_unstable();
+        assert_eq!(remaining, sorted);
+        assert_eq!(*remaining.last().unwrap(), 1_700_000_005_000);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rejects_a_corrupt_file() {
+        let dir = tempdir();
+        let spool = Spool::new(dir.clone(), DEFAULT_MAX_BYTES).unwrap();
+        spool.push(&frame(1_700_000_000_000)).unwrap();
+        let path = spool.pending(1).remove(0);
+        fs::write(&path, b"JUNKjunkjunk").unwrap();
+        assert!(Spool::load(&path).is_err());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    fn tempdir() -> PathBuf {
+        let p = std::env::temp_dir().join(format!("vantyr-spool-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+}

--- a/agent/src/secure_desktop.rs
+++ b/agent/src/secure_desktop.rs
@@ -1,0 +1,132 @@
+//! Secure-desktop attachment helpers (Windows).
+//!
+//! Windows has multiple *desktops* inside the interactive window station
+//! `WinSta0`: the normal `Default` desktop, and the secure `Winlogon` desktop
+//! used by the sign-in / lock / UAC screens. A thread can only capture pixels
+//! from — or inject input into — the desktop it is **attached** to
+//! (`SetThreadDesktop`), and a given desktop's DACL only grants access to
+//! SYSTEM plus, for `Default`, the signed-in user. That is why the ordinary
+//! user-session agent can never see the lock screen: it is pinned to `Default`
+//! and its token has no rights on `Winlogon`.
+//!
+//! These helpers let the SYSTEM capture worker attach the *calling thread* to
+//! whichever desktop currently receives input, and notice when that changes
+//! (sign-in → lock → UAC prompt → unlock). The worker re-runs
+//! [`attach_current_thread_to_input_desktop`] and rebuilds its capture/input
+//! state whenever [`input_desktop_name`] changes.
+
+use anyhow::{bail, Context, Result};
+use windows::Win32::Foundation::HANDLE;
+use windows::Win32::System::StationsAndDesktops::{
+    CloseDesktop, GetUserObjectInformationW, OpenInputDesktop, SetThreadDesktop,
+    DESKTOP_ACCESS_FLAGS, DESKTOP_CONTROL_FLAGS, HDESK, UOI_NAME,
+};
+
+/// All object-specific desktop rights (`DESKTOP_*`) OR'd together
+/// (`DESKTOP_ALL_ACCESS` minus the standard-rights bits). Enough to read pixels
+/// from and inject input into the desktop after `SetThreadDesktop`.
+const DESKTOP_OBJECT_RIGHTS: u32 = 0x0000_01FF;
+
+/// RAII wrapper around a desktop handle attached to the current thread.
+///
+/// Dropping it closes the handle. Keep it alive for as long as the thread stays
+/// attached (i.e. for the lifetime of one capture/input generation); attaching a
+/// new desktop and dropping the old wrapper is the normal switch path.
+pub struct DesktopAttachment {
+    hdesk: HDESK,
+    name: String,
+}
+
+impl DesktopAttachment {
+    /// Name of the desktop this thread is attached to (e.g. `Default`, `Winlogon`).
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl Drop for DesktopAttachment {
+    fn drop(&mut self) {
+        // Best-effort: the thread should have moved off this desktop (or be exiting)
+        // before we close the handle.
+        let _ = unsafe { CloseDesktop(self.hdesk) };
+    }
+}
+
+/// Open the desktop currently receiving user input and attach the **calling
+/// thread** to it. Must be called before the thread creates any windows/hooks —
+/// `SetThreadDesktop` fails once the thread owns UI objects, so callers run
+/// capture/input on a freshly spawned thread and re-attach by respawning.
+///
+/// Returns an error when there is no reachable input desktop (rare, transient
+/// during session transitions) so the caller can back off and retry.
+pub fn attach_current_thread_to_input_desktop() -> Result<DesktopAttachment> {
+    // DF_ALLOWOTHERACCOUNTHOOK = 1; 0 is fine — we are SYSTEM and own the desktop.
+    let hdesk = unsafe {
+        OpenInputDesktop(
+            DESKTOP_CONTROL_FLAGS(0),
+            false,
+            DESKTOP_ACCESS_FLAGS(DESKTOP_OBJECT_RIGHTS),
+        )
+    }
+    .context("OpenInputDesktop (no reachable input desktop)")?;
+
+    if let Err(e) = unsafe { SetThreadDesktop(hdesk) } {
+        let _ = unsafe { CloseDesktop(hdesk) };
+        bail!("SetThreadDesktop failed: {e}");
+    }
+
+    let name = desktop_name(hdesk).unwrap_or_default();
+    Ok(DesktopAttachment { hdesk, name })
+}
+
+/// Name of the desktop that currently owns input, without attaching to it.
+///
+/// Used as a cheap change-detector: capture/input threads poll this and, when it
+/// differs from the desktop they attached to, exit so a supervisor re-attaches to
+/// the new one. Returns `None` transiently when no input desktop is reachable.
+pub fn input_desktop_name() -> Option<String> {
+    let hdesk = unsafe {
+        OpenInputDesktop(
+            DESKTOP_CONTROL_FLAGS(0),
+            false,
+            DESKTOP_ACCESS_FLAGS(DESKTOP_OBJECT_RIGHTS),
+        )
+    }
+    .ok()?;
+    let name = desktop_name(hdesk).ok();
+    let _ = unsafe { CloseDesktop(hdesk) };
+    name
+}
+
+fn desktop_name(hdesk: HDESK) -> Result<String> {
+    // First call: ask for the required byte length.
+    let mut needed: u32 = 0;
+    let handle = HANDLE(hdesk.0);
+    // A zero-length probe returns ERROR_INSUFFICIENT_BUFFER and fills `needed`.
+    let _ = unsafe {
+        GetUserObjectInformationW(handle, UOI_NAME, None, 0, Some(&raw mut needed))
+    };
+    if needed == 0 {
+        // Fall back to a reasonable fixed buffer if the probe gave nothing.
+        needed = 256;
+    }
+
+    let mut buf = vec![0u8; needed as usize];
+    unsafe {
+        GetUserObjectInformationW(
+            handle,
+            UOI_NAME,
+            Some(buf.as_mut_ptr().cast()),
+            needed,
+            Some(&raw mut needed),
+        )
+    }
+    .context("GetUserObjectInformationW(UOI_NAME)")?;
+
+    // The buffer holds a wide, NUL-terminated string.
+    let wide: &[u16] = unsafe {
+        std::slice::from_raw_parts(buf.as_ptr().cast::<u16>(), (needed as usize) / 2)
+    };
+    let end = wide.iter().position(|&c| c == 0).unwrap_or(wide.len());
+    Ok(String::from_utf16_lossy(&wide[..end]))
+}

--- a/agent/src/server_command.rs
+++ b/agent/src/server_command.rs
@@ -294,6 +294,12 @@ pub fn handle_server_command(args: ServerCommandArgs<'_>) {
                 warn!("update_now is not implemented for the Linux headless agent yet.");
             }
         }
+        "start_capture" if crate::role::suppresses_capture_and_input() => {
+            // Service-managed companion: the SYSTEM capture worker owns live screen
+            // capture (it can also reach the lock/sign-in desktop). Ignore here so
+            // the same monitor isn't captured twice.
+        }
+        "stop_capture" if crate::role::suppresses_capture_and_input() => {}
         "start_capture" => {
             let settings =
                 crate::platform::desktop_capture::CaptureSettings::from_server_command(&val);
@@ -1064,6 +1070,11 @@ pub fn handle_server_command(args: ServerCommandArgs<'_>) {
             if done {
                 push_result(path, true, String::new(), out_tx);
             }
+        }
+        // Remote input (MouseMove/Click/Key*/TypeText/…) falls through here.
+        _ if crate::role::suppresses_capture_and_input() => {
+            // Service-managed companion: the SYSTEM capture worker injects input
+            // (and can drive the lock/sign-in desktop). Ignore here.
         }
         _ => match controller {
             Some(ctrl) => {

--- a/agent/src/server_command.rs
+++ b/agent/src/server_command.rs
@@ -42,6 +42,8 @@ pub struct ServerCommandArgs<'a> {
     pub(crate) config_tx: &'a tokio::sync::watch::Sender<Option<Config>>,
     pub(crate) out_tx: mpsc::Sender<Message>,
     pub(crate) shared_rules: &'a crate::app_block::SharedRules,
+    /// Live capture tunables, shared with the screen-history capture thread.
+    pub(crate) history_settings: &'a Arc<Mutex<crate::screen_history::HistorySettings>>,
 }
 
 pub fn handle_server_command(args: ServerCommandArgs<'_>) {
@@ -55,6 +57,7 @@ pub fn handle_server_command(args: ServerCommandArgs<'_>) {
         config_tx,
         out_tx,
         shared_rules,
+        history_settings,
     } = args;
 
     let val: serde_json::Value = match serde_json::from_str(text) {
@@ -224,6 +227,33 @@ pub fn handle_server_command(args: ServerCommandArgs<'_>) {
                 });
             }
         }
+        // ── Recall capture settings ─────────────────────────────────────────
+        // Applied live (the capture thread re-reads every tick) and cached in config
+        // so cadence/quality and the operator kill switch survive restarts and keep
+        // applying while offline.
+        "set_recall_settings" => {
+            match serde_json::from_value::<crate::screen_history::HistorySettings>(
+                val["settings"].clone(),
+            ) {
+                Ok(next) => {
+                    *history_settings.lock().unwrap_or_else(|e| e.into_inner()) = next;
+                    if let Ok(mut c) = shared_cfg.lock() {
+                        c.recall_settings = Some(next);
+                        if let Err(e) = tokio::task::block_in_place(|| {
+                            crate::config::save_config_from_user_session(&c)
+                        }) {
+                            warn!("Failed to save Recall capture settings to config: {e}");
+                        }
+                    }
+                    info!(
+                        "Recall capture settings updated from server (enabled={}, interval={}ms, q={}).",
+                        next.enabled, next.interval_ms, next.jpeg_quality
+                    );
+                }
+                Err(e) => warn!("Ignoring malformed set_recall_settings payload: {e}"),
+            }
+        }
+
         "set_app_block_rules" => {
             let empty: Vec<serde_json::Value> = Vec::new();
             let rules: Vec<crate::app_block::BlockRule> = val["rules"]

--- a/agent/src/service.rs
+++ b/agent/src/service.rs
@@ -13,9 +13,9 @@ use windows::Win32::Security::Authorization::{
 };
 use windows::Win32::Security::{
     AdjustTokenPrivileges, DuplicateTokenEx, LookupPrivilegeValueW, SecurityImpersonation,
-    TokenPrimary, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES, SE_PRIVILEGE_ENABLED,
-    TOKEN_ACCESS_MASK, TOKEN_ADJUST_DEFAULT, TOKEN_ADJUST_PRIVILEGES, TOKEN_ADJUST_SESSIONID,
-    TOKEN_ASSIGN_PRIMARY, TOKEN_DUPLICATE, TOKEN_PRIVILEGES, TOKEN_QUERY,
+    SetTokenInformation, TokenPrimary, TokenSessionId, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES,
+    SE_PRIVILEGE_ENABLED, TOKEN_ACCESS_MASK, TOKEN_ADJUST_DEFAULT, TOKEN_ADJUST_PRIVILEGES,
+    TOKEN_ADJUST_SESSIONID, TOKEN_ASSIGN_PRIMARY, TOKEN_DUPLICATE, TOKEN_PRIVILEGES, TOKEN_QUERY,
 };
 use windows::Win32::Security::{GetTokenInformation, TokenUser};
 use windows::Win32::System::Environment::{CreateEnvironmentBlock, DestroyEnvironmentBlock};
@@ -373,10 +373,14 @@ fn service_main(_arguments: Vec<std::ffi::OsString>) {
 }
 
 fn run_service() -> windows_service::Result<()> {
-    // Needed on some machines for CreateProcessAsUserW.
-    if let Err(e) =
-        enable_privileges(&["SeIncreaseQuotaPrivilege", "SeAssignPrimaryTokenPrivilege"])
-    {
+    // Needed on some machines for CreateProcessAsUserW. `SeTcbPrivilege` is
+    // additionally required to retarget a duplicated token at the console session
+    // (SetTokenInformation/TokenSessionId) when launching the SYSTEM capture worker.
+    if let Err(e) = enable_privileges(&[
+        "SeIncreaseQuotaPrivilege",
+        "SeAssignPrimaryTokenPrivilege",
+        "SeTcbPrivilege",
+    ]) {
         warn!("Failed enabling service privileges: {e:#}");
     }
 
@@ -405,6 +409,10 @@ fn run_service() -> windows_service::Result<()> {
 
     info!("Service started; waiting for user sessions and update requests.");
     let mut launched_for_session: Option<u32> = None;
+    // The SYSTEM capture worker is launched into the console session separately:
+    // it does not need a signed-in user (so it is present at the lock/sign-in
+    // screen), whereas the user-session companion does.
+    let mut worker_launched_for_session: Option<u32> = None;
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(2)
@@ -452,17 +460,41 @@ fn run_service() -> windows_service::Result<()> {
                 Err(mpsc::TryRecvError::Disconnected) => {}
             }
 
-            // Keep user-agent running in the active session.
+            // Keep the user companion and the SYSTEM capture worker running in the
+            // active console session.
             let active_session = unsafe { WTSGetActiveConsoleSessionId() };
             if active_session == u32::MAX {
+                // No console session attached (e.g. RDP-only / transitioning).
                 launched_for_session = None;
-            } else if launched_for_session != Some(active_session) {
-                match launch_user_agent_in_session(active_session) {
-                    Ok(()) => {
-                        launched_for_session = Some(active_session);
-                        info!("Launched agent process in user session {active_session}.");
+                worker_launched_for_session = None;
+            } else {
+                // User-session companion: only possible once a user is signed in
+                // (WTSQueryUserToken). Retries every tick until then.
+                if launched_for_session != Some(active_session) {
+                    match launch_user_agent_in_session(active_session) {
+                        Ok(()) => {
+                            launched_for_session = Some(active_session);
+                            info!("Launched agent process in user session {active_session}.");
+                        }
+                        Err(e) => {
+                            warn!("Failed launching agent in session {active_session}: {e:#}");
+                        }
                     }
-                    Err(e) => warn!("Failed launching agent in session {active_session}: {e:#}"),
+                }
+
+                // SYSTEM capture worker: launched with the service's own token
+                // retargeted at the console session, so it comes up at the
+                // sign-in/lock screen before any user token exists.
+                if worker_launched_for_session != Some(active_session) {
+                    match launch_capture_worker_in_session(active_session) {
+                        Ok(()) => {
+                            worker_launched_for_session = Some(active_session);
+                            info!("Launched SYSTEM capture worker in session {active_session}.");
+                        }
+                        Err(e) => warn!(
+                            "Failed launching capture worker in session {active_session}: {e:#}"
+                        ),
+                    }
                 }
             }
 
@@ -845,7 +877,7 @@ fn launch_user_agent_in_session(session_id: u32) -> Result<()> {
     // Force user-agent logs into a stable location so service-started failures are visible.
     let user_log = program_data_path("user-agent.log");
     let cmdline = format!(
-        "\"{}\" --log-file \"{}\"",
+        "\"{}\" --service-managed --log-file \"{}\"",
         exe.display(),
         user_log.display()
     );
@@ -898,6 +930,128 @@ fn launch_user_agent_in_session(session_id: u32) -> Result<()> {
     let _ = unsafe { CloseHandle(impersonation_token) };
 
     create_result.ok().context("CreateProcessAsUserW failed")?;
+    Ok(())
+}
+
+/// Launch the SYSTEM capture worker into the console session `session_id`.
+///
+/// Unlike [`launch_user_agent_in_session`], this needs no signed-in user: it
+/// duplicates the service's own LocalSystem token and retargets it at the
+/// session (`SetTokenInformation`/`TokenSessionId`, which requires
+/// `SeTcbPrivilege`), so the worker is present from the sign-in/lock screen
+/// onward. The worker attaches its own threads to the live input desktop; the
+/// process-level `winsta0\default` here is only the initial desktop.
+fn launch_capture_worker_in_session(session_id: u32) -> Result<()> {
+    use std::ffi::c_void;
+    use windows::Win32::System::Threading::CREATE_NO_WINDOW;
+
+    // 1. Open the service's own (LocalSystem) process token.
+    let mut proc_token = HANDLE::default();
+    unsafe {
+        OpenProcessToken(
+            GetCurrentProcess(),
+            TOKEN_DUPLICATE
+                | TOKEN_QUERY
+                | TOKEN_ASSIGN_PRIMARY
+                | TOKEN_ADJUST_DEFAULT
+                | TOKEN_ADJUST_SESSIONID,
+            &raw mut proc_token,
+        )
+    }
+    .ok()
+    .context("OpenProcessToken(service) failed")?;
+
+    // 2. Duplicate it into a primary token we can retarget and assign.
+    let access: TOKEN_ACCESS_MASK = TOKEN_ASSIGN_PRIMARY
+        | TOKEN_DUPLICATE
+        | TOKEN_QUERY
+        | TOKEN_ADJUST_DEFAULT
+        | TOKEN_ADJUST_SESSIONID;
+    let mut primary_token = HANDLE::default();
+    let dup = unsafe {
+        DuplicateTokenEx(
+            proc_token,
+            access,
+            None,
+            SecurityImpersonation,
+            TokenPrimary,
+            &raw mut primary_token,
+        )
+    };
+    let _ = unsafe { CloseHandle(proc_token) };
+    dup.ok().context("DuplicateTokenEx(service token) failed")?;
+
+    // 3. Retarget the token at the console session (requires SeTcbPrivilege).
+    let sid: u32 = session_id;
+    if let Err(e) = unsafe {
+        SetTokenInformation(
+            primary_token,
+            TokenSessionId,
+            (&raw const sid).cast::<c_void>(),
+            std::mem::size_of::<u32>() as u32,
+        )
+    } {
+        let _ = unsafe { CloseHandle(primary_token) };
+        return Err(anyhow::anyhow!("SetTokenInformation(TokenSessionId): {e}"));
+    }
+
+    // 4. Command line + a SYSTEM environment block for the target session.
+    let exe = std::env::current_exe().context("Cannot resolve current executable path")?;
+    let worker_log = program_data_path("capture-worker.log");
+    let cmdline = format!(
+        "\"{}\" --capture-worker --no-ui --log-file \"{}\"",
+        exe.display(),
+        worker_log.display()
+    );
+    let mut cmdline_w = to_wide_z(&cmdline);
+    let desktop_w = to_wide_z("winsta0\\default");
+
+    let startup = STARTUPINFOW {
+        cb: std::mem::size_of::<STARTUPINFOW>() as u32,
+        lpDesktop: PWSTR(desktop_w.as_ptr().cast_mut()),
+        ..Default::default()
+    };
+
+    let mut env_block: *mut core::ffi::c_void = std::ptr::null_mut();
+    unsafe { CreateEnvironmentBlock(&raw mut env_block, Some(primary_token), false) }
+        .ok()
+        .context("CreateEnvironmentBlock(worker) failed")?;
+
+    let creation_flags: PROCESS_CREATION_FLAGS = CREATE_UNICODE_ENVIRONMENT | CREATE_NO_WINDOW;
+
+    let mut proc_info = PROCESS_INFORMATION::default();
+    let create_result = unsafe {
+        CreateProcessAsUserW(
+            Some(primary_token),
+            PCWSTR::null(),
+            Some(PWSTR(cmdline_w.as_mut_ptr())),
+            None,
+            None,
+            false,
+            creation_flags,
+            Some(env_block),
+            PCWSTR::null(),
+            &raw const startup,
+            &raw mut proc_info,
+        )
+    };
+
+    let _ = unsafe { DestroyEnvironmentBlock(env_block) };
+
+    if create_result.is_ok() {
+        info!(
+            "Capture worker CreateProcessAsUserW ok (pid={}, session={}).",
+            proc_info.dwProcessId, session_id
+        );
+    }
+
+    let _ = unsafe { CloseHandle(proc_info.hProcess) };
+    let _ = unsafe { CloseHandle(proc_info.hThread) };
+    let _ = unsafe { CloseHandle(primary_token) };
+
+    create_result
+        .ok()
+        .context("CreateProcessAsUserW(worker) failed")?;
     Ok(())
 }
 

--- a/agent/src/system_info.rs
+++ b/agent/src/system_info.rs
@@ -482,10 +482,17 @@ pub fn collect_agent_info() -> serde_json::Value {
         .or_else(env_username_fallback)
         .unwrap_or_default();
 
+    // IANA timezone of this machine (e.g. "Australia/Perth"). The server uses it to
+    // bucket Recall activity into the user's *local* day; without it a day summary
+    // for anyone east or west of UTC covers the wrong 24 hours and splits their
+    // real day across two rows. `None` if the OS timezone can't be mapped.
+    let timezone = iana_time_zone::get_timezone().ok();
+
     json!({
         "type": "agent_info",
         "agent_version": app_version,
         "hostname": hostname,
+        "timezone": timezone,
         "uptime_secs": uptime_secs,
         "os_name": os_name,
         "os_version": os_version,

--- a/agent/src/ui.rs
+++ b/agent/src/ui.rs
@@ -473,6 +473,7 @@ fn save_config(
         preserve_internet_block_rules,
         preserve_app_block_rules,
         preserve_screen_history_enabled,
+        preserve_recall_settings,
     ) = {
         let cur = stored.0.lock().unwrap_or_else(|e| e.into_inner());
         (
@@ -480,6 +481,7 @@ fn save_config(
             cur.internet_block_rules.clone(),
             cur.app_block_rules.clone(),
             cur.screen_history_enabled,
+            cur.recall_settings,
         )
     };
 
@@ -508,8 +510,9 @@ fn save_config(
         internet_block_rules: preserve_internet_block_rules,
         // Preserve app block rules; managed remotely.
         app_block_rules: preserve_app_block_rules,
-        // Preserve screen-history toggle; managed remotely.
+        // Preserve screen-history toggle and capture tunables; managed remotely.
         screen_history_enabled: preserve_screen_history_enabled,
+        recall_settings: preserve_recall_settings,
     };
 
     crate::config::save_config_from_user_session(&new_cfg).map_err(|e| e.to_string())?;

--- a/frontend/src/demo/api.ts
+++ b/frontend/src/demo/api.ts
@@ -409,12 +409,20 @@ export function createDemoApi(realApi: ApiClient): ApiClient {
         : [];
       return { query: q, from: new Date(from).toISOString(), to: new Date(to).toISOString(), count: results.length, results };
     },
+    // Demo has no real OCR geometry; return none so the overlay stays inert rather
+    // than drawing selectable text that doesn't line up with the fake desktop.
+    historyFrameText: async () => ({ text: null, words: [] }),
     historySegments: async (_id, day) => {
-      const d = typeof day === "string" && day ? day : new Date().toISOString().slice(0, 10);
-      return { day: d, count: demoSegments(d).length, segments: demoSegments(d) };
+      const d = typeof day === "string" && day ? day : demoToday();
+      return {
+        day: d,
+        timezone: demoTimezone(),
+        count: demoSegments(d).length,
+        segments: demoSegments(d),
+      };
     },
     historyDaySummary: async (_id, day) => {
-      const d = typeof day === "string" && day ? day : new Date().toISOString().slice(0, 10);
+      const d = typeof day === "string" && day ? day : demoToday();
       const segs = demoSegments(d);
       const byCat: Record<string, number> = {};
       const byApp: Record<string, number> = {};
@@ -431,6 +439,7 @@ export function createDemoApi(realApi: ApiClient): ApiClient {
         .map(([app, seconds]) => ({ app, seconds }));
       return {
         day: d,
+        timezone: demoTimezone(),
         summary: {
           day: d,
           narrative:
@@ -546,6 +555,16 @@ function demoFramesList(fromMs: number, toMs: number): ReturnType<typeof demoFra
 }
 
 /** Synthetic activity segments for a given day (YYYY-MM-DD). */
+/** The demo "agent" lives in the viewer's own zone, so the demo day matches the clock. */
+function demoTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+}
+
+/** Today as a local `YYYY-MM-DD` (not the UTC date `toISOString` would give). */
+function demoToday(): string {
+  return new Date().toLocaleDateString("en-CA");
+}
+
 function demoSegments(day: string): {
   id: number;
   start_ts: string;

--- a/frontend/src/layouts/DashboardLayout.tsx
+++ b/frontend/src/layouts/DashboardLayout.tsx
@@ -242,34 +242,19 @@ export function DashboardLayout({
             <VI.logo style={{ width: 22, height: 22, flexShrink: 0 }} />
           </div>
           {!collapsed && (
-            <>
-              <span
-                style={{
-                  fontSize: 17,
-                  fontWeight: 700,
-                  fontFamily: "var(--display)",
-                  color: "var(--tx)",
-                  letterSpacing: "-0.01em",
-                  lineHeight: "25px",
-                  height: "25px",
-                }}
-              >
-                Vantyr
-              </span>
-              <span
-                style={{
-                  fontSize: 9,
-                  fontWeight: 700,
-                  color: "var(--gr)",
-                  background: "var(--gr-soft)",
-                  padding: "2px 6px",
-                  borderRadius: 5,
-                  marginTop: 1,
-                }}
-              >
-                BETA
-              </span>
-            </>
+            <span
+              style={{
+                fontSize: 17,
+                fontWeight: 700,
+                fontFamily: "var(--display)",
+                color: "var(--tx)",
+                letterSpacing: "-0.01em",
+                lineHeight: "25px",
+                height: "25px",
+              }}
+            >
+              Vantyr
+            </span>
           )}
         </div>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   ScreenSearchResponse,
   ActivitySegmentsResponse,
   DaySummaryResponse,
+  FrameTextResponse,
   AgentSoftwareRow,
   RetentionPolicy,
   StorageUsage,
@@ -222,6 +223,7 @@ async function delJson<T>(path: string): Promise<T> {
   });
 }
 
+
 export const realApi = {
   // ── Auth ──────────────────────────────────────────────────────────────────
 
@@ -380,6 +382,10 @@ export const realApi = {
   historyBlobUrl: (id: string, frameId: number): string =>
     apiUrl(`/agents/${id}/history/blob/${frameId}`),
 
+  /** OCR text + per-word boxes for one frame (drives the selectable-text overlay). */
+  historyFrameText: (id: string, frameId: number): Promise<FrameTextResponse> =>
+    get(`/agents/${id}/history/text/${frameId}`),
+
   /** Ranked OCR full-text search over an agent's keyframes in a time range. */
   historySearch: (
     id: string,
@@ -395,13 +401,17 @@ export const realApi = {
     return get(`/agents/${id}/history/search?${params.toString()}`);
   },
 
-  /** Derived activity segments for one day (YYYY-MM-DD, UTC; defaults to today). */
+  /**
+   * Derived activity segments for one day (`YYYY-MM-DD` in the **agent's** local
+   * timezone, which the response echoes back; defaults to today there).
+   */
   historySegments: (id: string, day?: string): Promise<ActivitySegmentsResponse> =>
     get(`/agents/${id}/history/segments${day ? `?day=${day}` : ""}`),
 
-  /** AI/rule day-narrative + totals for one day. */
+  /** AI/rule day-narrative + totals for one day (agent-local, as above). */
   historyDaySummary: (id: string, day?: string): Promise<DaySummaryResponse> =>
     get(`/agents/${id}/history/day-summary${day ? `?day=${day}` : ""}`),
+
 
   topUrls: (
     id: string,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -307,8 +307,29 @@ export interface ActivitySegment {
 
 export interface ActivitySegmentsResponse {
   day: string;
+  /** IANA zone the `day` is expressed in — the agent's, not the viewer's. */
+  timezone: string;
   count: number;
   segments: ActivitySegment[];
+}
+
+/**
+ * One OCR'd word and its box on a keyframe, normalized to 0..1 of the frame — so the
+ * overlay positions correctly regardless of capture resolution or rendered size.
+ */
+export interface OcrWord {
+  /** The word text. */
+  t: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** OCR text + word geometry for one frame, fetched lazily for the visible frame. */
+export interface FrameTextResponse {
+  text: string | null;
+  words: OcrWord[];
 }
 
 /** Per-day summary: AI/rule narrative + aggregate totals. */
@@ -328,6 +349,8 @@ export interface DaySummary {
 
 export interface DaySummaryResponse {
   day: string;
+  /** IANA zone the `day` is expressed in — the agent's, not the viewer's. */
+  timezone: string;
   summary: DaySummary | null;
 }
 

--- a/frontend/src/pages/RecallPage.tsx
+++ b/frontend/src/pages/RecallPage.tsx
@@ -16,6 +16,7 @@ import type {
   ActivityPoint,
   ActivitySegment,
   DaySummary,
+  OcrWord,
   ScreenFrame,
   ScreenFrameSearchResult,
 } from "../lib/types";
@@ -36,8 +37,25 @@ function catColor(cat: string): string {
   return CATEGORY_COLOR[cat] ?? CATEGORY_COLOR.other;
 }
 
-function todayIso(): string {
-  return new Date().toISOString().slice(0, 10);
+/**
+ * Today's calendar date in `tz` (or the viewer's own zone if unspecified), as
+ * `YYYY-MM-DD`.
+ *
+ * Deliberately not `toISOString().slice(0, 10)`: that is the *UTC* date, so for
+ * anyone east of UTC it names tomorrow late in the evening, and for anyone west it
+ * names yesterday in the morning. `en-CA` formats as `YYYY-MM-DD`.
+ */
+function todayIso(tz?: string): string {
+  return new Date().toLocaleDateString("en-CA", tz ? { timeZone: tz } : undefined);
+}
+
+/** Time-of-day in the agent's zone, so labels match the day they're filed under. */
+function timeIn(tz: string | null, iso: string): string {
+  return new Date(iso).toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+    ...(tz ? { timeZone: tz } : {}),
+  });
 }
 
 /** Render a ts_headline snippet, bolding the [[[…]]]-delimited matched terms (safe: no HTML). */
@@ -100,11 +118,22 @@ export function RecallPage() {
   const [summaryDay, setSummaryDay] = useState<string>(todayIso());
   const [daySummary, setDaySummary] = useState<DaySummary | null>(null);
   const [segments, setSegments] = useState<ActivitySegment[]>([]);
+  // The agent's IANA zone, reported alongside the day. Day rows are bucketed in the
+  // agent's local day, so times must be rendered in it too — otherwise an operator in
+  // a different zone sees a session list that contradicts the date above it.
+  const [dayTimezone, setDayTimezone] = useState<string | null>(null);
   const [loadingDay, setLoadingDay] = useState(false);
 
   const [loadingAgents, setLoadingAgents] = useState(true);
   const [loadingFrames, setLoadingFrames] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // OCR word boxes for the frame currently on screen.
+  const [words, setWords] = useState<OcrWord[]>([]);
+  const [showText, setShowText] = useState(false);
+  // Rendered size of the <img>. Word boxes are normalized 0..1, so turning them into
+  // a readable font size needs the actual pixel height the frame is drawn at.
+  const imgRef = useRef<HTMLImageElement | null>(null);
+  const [imgHeight, setImgHeight] = useState(0);
 
   // ── Load the agent list once, filtered to agents that actually have recall history ──
   useEffect(() => {
@@ -151,36 +180,103 @@ export function RecallPage() {
       .catch(() => setActivity(null));
   }, [agentId, preset]);
 
-  // OCR search, scoped to the currently loaded range so every hit maps to a scrubber index.
+  /**
+   * OCR search across **all** retained history, not just the loaded window.
+   *
+   * Scoping search to the visible range made "when did I last see X?" unanswerable
+   * unless you had already guessed the right range. Hits outside the window are
+   * handled by `jumpToTime`, which loads frames around the result first.
+   */
   const runSearch = useCallback(() => {
     const q = query.trim();
-    if (!agentId || !q || !loadedRange) return;
+    if (!agentId || !q) return;
     setSearching(true);
+    setError(null);
+    // Far wider than any plausible retention setting; the server clamps results.
+    const to = new Date();
+    const from = new Date(to.getTime() - 365 * 24 * 3600 * 1000);
     api
-      .historySearch(agentId, q, loadedRange.from, loadedRange.to, 100)
+      .historySearch(agentId, q, from.toISOString(), to.toISOString(), 100)
       .then((res) => setResults(res.results))
       .catch(() => setError("Search failed."))
       .finally(() => setSearching(false));
-  }, [agentId, query, loadedRange]);
+  }, [agentId, query]);
 
-  // Jump the scrubber to the loaded frame nearest a search hit's timestamp.
+  // Jump the scrubber to the loaded frame nearest a timestamp.
+  //
+  // `frames` is ordered by captured_at, so this binary-searches rather than scanning
+  // — the range cap is 3000 frames and this runs on every ribbon/segment/result click.
   const jumpToFrame = useCallback(
     (target: string) => {
       if (frames.length === 0) return;
       const t = new Date(target).getTime();
-      let best = 0;
-      let bestDiff = Infinity;
-      frames.forEach((f, i) => {
-        const d = Math.abs(new Date(f.captured_at).getTime() - t);
-        if (d < bestDiff) {
-          bestDiff = d;
-          best = i;
-        }
-      });
+      let lo = 0;
+      let hi = frames.length - 1;
+      while (lo < hi) {
+        const mid = (lo + hi) >> 1;
+        if (new Date(frames[mid].captured_at).getTime() < t) lo = mid + 1;
+        else hi = mid;
+      }
+      // `lo` is the first frame at-or-after t; the one before may be nearer.
+      const prev = Math.max(0, lo - 1);
+      const dLo = Math.abs(new Date(frames[lo].captured_at).getTime() - t);
+      const dPrev = Math.abs(new Date(frames[prev].captured_at).getTime() - t);
       setPlaying(false);
-      setIndex(best);
+      setIndex(dPrev <= dLo ? prev : lo);
     },
     [frames],
+  );
+
+  /**
+   * Jump to a timestamp that may fall outside the loaded window.
+   *
+   * Search spans all retained history, so a hit can easily land days outside the
+   * currently loaded range — where `jumpToFrame` would silently clamp to the nearest
+   * loaded edge and show the wrong screen. Load a window around the target first,
+   * then land on it.
+   */
+  const jumpToTime = useCallback(
+    (target: string) => {
+      if (!agentId) return;
+      const t = new Date(target).getTime();
+      const inRange =
+        loadedRange !== null &&
+        t >= new Date(loadedRange.from).getTime() &&
+        t <= new Date(loadedRange.to).getTime();
+      if (inRange) {
+        jumpToFrame(target);
+        return;
+      }
+      const from = new Date(t - 30 * 60 * 1000);
+      const to = new Date(t + 30 * 60 * 1000);
+      setLoadingFrames(true);
+      setPlaying(false);
+      setError(null);
+      setLoadedRange({ from: from.toISOString(), to: to.toISOString() });
+      api
+        .historyFrames(agentId, from.toISOString(), to.toISOString(), 3000)
+        .then((res) => {
+          setFrames(res.frames);
+          // Land on the nearest frame in the freshly loaded window.
+          let best = 0;
+          let bestDiff = Infinity;
+          res.frames.forEach((f, i) => {
+            const d = Math.abs(new Date(f.captured_at).getTime() - t);
+            if (d < bestDiff) {
+              bestDiff = d;
+              best = i;
+            }
+          });
+          setIndex(best);
+        })
+        .catch(() => setError("Failed to load screen history around that moment."))
+        .finally(() => setLoadingFrames(false));
+      api
+        .historyActivity(agentId, from.toISOString(), to.toISOString(), 120)
+        .then((res) => setActivity({ points: res.points, bucketSecs: res.bucket_secs }))
+        .catch(() => setActivity(null));
+    },
+    [agentId, loadedRange, jumpToFrame],
   );
 
   // Dense buckets across the loaded range (0-filled gaps) for the activity strip.
@@ -219,11 +315,13 @@ export function RecallPage() {
         if (!alive) return;
         setDaySummary(sum.summary);
         setSegments(segs.segments);
+        setDayTimezone(sum.timezone ?? segs.timezone ?? null);
       })
       .catch(() => {
         if (!alive) return;
         setDaySummary(null);
         setSegments([]);
+        setDayTimezone(null);
       })
       .finally(() => alive && setLoadingDay(false));
     return () => {
@@ -259,6 +357,64 @@ export function RecallPage() {
     () => (agentId && current ? api.historyBlobUrl(agentId, current.id) : null),
     [agentId, current],
   );
+
+  // Track the image's rendered height so overlay glyphs scale with it (window
+  // resize, sidebar collapse, letterboxing changes).
+  useEffect(() => {
+    const el = imgRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(() => setImgHeight(el.clientHeight));
+    ro.observe(el);
+    setImgHeight(el.clientHeight);
+    return () => ro.disconnect();
+  }, [blobUrl, showText]);
+
+  // ── Selectable text overlay ──
+  // Word boxes for the frame on screen. Fetched per frame rather than with the range
+  // listing: 3000 frames' worth of word geometry would dwarf the metadata it rides on.
+  // Skipped during playback — nobody selects text off a moving timelapse, and it would
+  // fire a request per frame.
+  useEffect(() => {
+    if (!agentId || !current || playing || !current.has_ocr) {
+      setWords([]);
+      return;
+    }
+    let alive = true;
+    api
+      .historyFrameText(agentId, current.id)
+      .then((res) => alive && setWords(res.words ?? []))
+      .catch(() => alive && setWords([]));
+    return () => {
+      alive = false;
+    };
+  }, [agentId, current, playing]);
+
+  // ── Decode-ahead ──
+  // Each frame is a separate HTTP fetch, so at 4× (one frame every 160ms) playback
+  // outruns the network and stutters. Warm the browser cache for the frames just
+  // ahead of the playhead; the blob endpoint sends a long private max-age, so by
+  // the time the <img> src flips the bytes are already local.
+  const prefetched = useRef<Set<number>>(new Set());
+  useEffect(() => {
+    // Reloading the range invalidates which ids are worth holding.
+    prefetched.current = new Set();
+  }, [loadedRange, agentId]);
+  useEffect(() => {
+    if (!agentId || frames.length === 0) return;
+    // Prefetch further ahead when playing fast, since there's less time per frame.
+    const ahead = playing ? Math.max(8, Math.round(4000 / speedMs)) : 3;
+    for (let i = index + 1; i <= index + ahead && i < frames.length; i++) {
+      const id = frames[i].id;
+      if (prefetched.current.has(id)) continue;
+      prefetched.current.add(id);
+      // Fire-and-forget: the Image is only a cache warmer, never rendered.
+      const img = new Image();
+      img.decoding = "async";
+      img.src = api.historyBlobUrl(agentId, id);
+    }
+    // Bound the memo set so a long scrub can't grow it without limit.
+    if (prefetched.current.size > 2000) prefetched.current = new Set();
+  }, [agentId, frames, index, playing, speedMs]);
 
   const agentOptions = useMemo(
     () =>
@@ -376,8 +532,8 @@ export function RecallPage() {
               onKeyDown={(e) => {
                 if (e.key === "Enter") runSearch();
               }}
-              placeholder="Search screen text (OCR)…"
-              disabled={!agentId || framesLen === 0}
+              placeholder="Search all screen text (OCR)…"
+              disabled={!agentId}
               style={{
                 flex: 1,
                 maxWidth: 460,
@@ -393,7 +549,7 @@ export function RecallPage() {
             <Button
               onClick={runSearch}
               loading={searching}
-              disabled={!agentId || framesLen === 0 || query.trim() === ""}
+              disabled={!agentId || query.trim() === ""}
             >
               Search
             </Button>
@@ -428,7 +584,7 @@ export function RecallPage() {
                 results.map((r) => (
                   <button
                     key={r.id}
-                    onClick={() => jumpToFrame(r.captured_at)}
+                    onClick={() => jumpToTime(r.captured_at)}
                     style={{
                       display: "flex",
                       flexDirection: "column",
@@ -488,15 +644,61 @@ export function RecallPage() {
               {loadingFrames ? (
                 <Spinner size="large" />
               ) : blobUrl ? (
-                <img
-                  src={blobUrl}
-                  alt={`Screen at ${current?.captured_at ?? ""}`}
-                  style={{
-                    maxWidth: "100%",
-                    maxHeight: "100%",
-                    objectFit: "contain",
-                  }}
-                />
+                // The wrapper shrink-wraps the letterboxed image so the word overlay
+                // shares its exact box — percentage coordinates then line up with the
+                // pixels regardless of how the 16:9 stage letterboxes the frame.
+                <div style={{ position: "relative", display: "inline-block", maxWidth: "100%", maxHeight: "100%" }}>
+                  <img
+                    ref={imgRef}
+                    src={blobUrl}
+                    alt={`Screen at ${current?.captured_at ?? ""}`}
+                    onLoad={(e) => setImgHeight(e.currentTarget.clientHeight)}
+                    style={{
+                      display: "block",
+                      maxWidth: "100%",
+                      maxHeight: "100%",
+                      objectFit: "contain",
+                    }}
+                  />
+                  {showText && words.length > 0 && (
+                    <div
+                      // Transparent, selectable text laid over the screenshot: drag to
+                      // select and copy text off a screen from weeks ago. Each span is
+                      // scaled to fill its box so selection highlights land on the
+                      // actual glyphs rather than floating above them.
+                      style={{
+                        position: "absolute",
+                        inset: 0,
+                        cursor: "text",
+                        userSelect: "text",
+                      }}
+                    >
+                      {words.map((w, i) => (
+                        <span
+                          key={i}
+                          style={{
+                            position: "absolute",
+                            left: `${w.x * 100}%`,
+                            top: `${w.y * 100}%`,
+                            width: `${w.w * 100}%`,
+                            height: `${w.h * 100}%`,
+                            // Absolute px from the box height and the image's rendered
+                            // height — a percentage font-size would resolve against the
+                            // parent's font, not the box, and glyphs would drift out of
+                            // alignment with the pixels underneath.
+                            fontSize: `${Math.max(1, w.h * imgHeight)}px`,
+                            lineHeight: 1,
+                            color: "transparent",
+                            whiteSpace: "pre",
+                            overflow: "hidden",
+                          }}
+                        >
+                          {w.t}{" "}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
               ) : (
                 <Box
                   textAlign="center"
@@ -528,6 +730,13 @@ export function RecallPage() {
               >
                 {playing ? "Pause" : "Play"}
               </Button>
+              <Button
+                onClick={() => setShowText((v) => !v)}
+                disabled={!current?.has_ocr}
+                ariaLabel={showText ? "Hide selectable text" : "Select text on this frame"}
+              >
+                {showText ? "Done" : "Select text"}
+              </Button>
               <input
                 type="range"
                 min={0}
@@ -555,7 +764,7 @@ export function RecallPage() {
                     {new Date(current.captured_at).toLocaleString()}
                     {current.has_ocr && (
                       <span
-                        title="Has OCR text (searchable in Phase 2)"
+                        title="This frame has OCR text and is searchable"
                         style={{ color: "var(--gr)", marginLeft: 8 }}
                       >
                         ●
@@ -651,17 +860,37 @@ export function RecallPage() {
                   color: "var(--tx)",
                 }}
               >
+                {/* Parsed as local midnight (no trailing Z) so the weekday matches
+                    the date string itself rather than shifting by the UTC offset. */}
                 {new Date(`${summaryDay}T00:00:00`).toLocaleDateString([], {
                   weekday: "long",
                   month: "long",
                   day: "numeric",
                 })}
+                {dayTimezone && (
+                  <span
+                    style={{
+                      marginLeft: 10,
+                      fontFamily: "var(--mono)",
+                      fontSize: 11.5,
+                      fontWeight: 400,
+                      color: "var(--tx-3)",
+                    }}
+                    title="Days are bucketed in the agent's local timezone"
+                  >
+                    {dayTimezone}
+                  </span>
+                )}
               </span>
               <input
                 type="date"
                 value={summaryDay}
-                max={todayIso()}
-                onChange={(e) => setSummaryDay(e.target.value || todayIso())}
+                // Cap at today *in the agent's zone* — an agent ahead of the viewer
+                // can legitimately already be on tomorrow's date.
+                max={todayIso(dayTimezone ?? undefined)}
+                onChange={(e) =>
+                  setSummaryDay(e.target.value || todayIso(dayTimezone ?? undefined))
+                }
                 style={{
                   padding: "5px 8px",
                   borderRadius: 8,
@@ -716,10 +945,7 @@ export function RecallPage() {
                         <button
                           key={seg.id}
                           onClick={() => jumpToFrame(seg.start_ts)}
-                          title={new Date(seg.start_ts).toLocaleTimeString([], {
-                            hour: "numeric",
-                            minute: "2-digit",
-                          })}
+                          title={timeIn(dayTimezone, seg.start_ts)}
                           style={{
                             flex: dur,
                             minWidth: 3,
@@ -776,10 +1002,7 @@ export function RecallPage() {
                             minWidth: 62,
                           }}
                         >
-                          {new Date(seg.start_ts).toLocaleTimeString([], {
-                            hour: "numeric",
-                            minute: "2-digit",
-                          })}
+                          {timeIn(dayTimezone, seg.start_ts)}
                         </span>
                         <span
                           style={{

--- a/server/migrations/0063_screen_frames_client_uid.sql
+++ b/server/migrations/0063_screen_frames_client_uid.sql
@@ -1,0 +1,23 @@
+-- Migration 0063: idempotent keyframe ingest (`client_uid`) for the Recall spool.
+--
+-- The agent no longer hands keyframes straight to the session socket (where every
+-- frame captured while disconnected was dropped). It writes them to a durable
+-- on-disk spool and deletes each only after the server acks it. That makes the
+-- ingest path at-least-once: a lost ack, or a session that dies between insert and
+-- ack, causes the agent to re-send the same keyframe on its next connection.
+--
+-- `client_uid` is the agent-generated id for a spooled frame. The unique index makes
+-- the re-send a no-op (`ON CONFLICT DO NOTHING`) instead of a duplicate row.
+--
+-- The partition key must be part of every unique constraint on a partitioned table,
+-- so the index is on (captured_at, client_uid) rather than client_uid alone. That is
+-- still exactly the dedup we need: a re-sent frame carries its original captured_at.
+--
+-- Nullable because frames ingested before this migration have no uid, and because a
+-- future non-spooling client could omit it; NULLs are never equal in a unique index,
+-- so they simply don't participate in dedup.
+
+ALTER TABLE screen_frames ADD COLUMN IF NOT EXISTS client_uid UUID;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_screen_frames_client_uid
+    ON screen_frames (captured_at, client_uid);

--- a/server/migrations/0064_drop_unused_segment_frame_refs.sql
+++ b/server/migrations/0064_drop_unused_segment_frame_refs.sql
@@ -1,0 +1,17 @@
+-- Migration 0064: drop the never-populated frame-reference columns on activity_segments.
+--
+-- `frame_start_id` / `frame_end_id` were added in 0061 to link a derived activity
+-- segment to its bounding keyframes, but nothing ever wrote them — the narrative
+-- worker builds segments from `window_events` and never resolves frame ids, so every
+-- row has had NULLs since the table was created.
+--
+-- The UI navigates by timestamp instead (`jumpToFrame` binary-searches the loaded
+-- frame list), which works across reloads and doesn't break when retention drops the
+-- partition holding the referenced frame. Dropping the columns removes a schema
+-- element that reads as a working foreign reference but isn't one.
+--
+-- Safe: no data is lost because no data was ever written. If segment→frame linking is
+-- wanted later it should be re-added with the worker populating it in the same change.
+
+ALTER TABLE activity_segments DROP COLUMN IF EXISTS frame_start_id;
+ALTER TABLE activity_segments DROP COLUMN IF EXISTS frame_end_id;

--- a/server/migrations/0065_day_summary_incremental.sql
+++ b/server/migrations/0065_day_summary_incremental.sql
@@ -1,0 +1,21 @@
+-- Migration 0065: make the Recall day-narrative worker incremental.
+--
+-- The worker rebuilt every agent's *entire* day every 15 minutes, including the
+-- optional vision-model call. That meant the AI cost for a single day grew with the
+-- number of ticks in it (~96 full-day calls per agent per day), and it only ever
+-- looked at "today" — so if the server was down or restarting at the end of a day,
+-- that day's final hours were never summarized and nothing ever went back to fix it.
+--
+-- These columns let the worker skip work that would produce an identical result:
+--
+--   content_hash   Fingerprint of the segments the summary was derived from. Unchanged
+--                  hash => nothing happened since the last run => skip entirely.
+--   ai_generated_at When the vision narrative was last produced, so AI calls can be
+--                  rate-limited independently of the cheap rule-based rebuild.
+--   finalized      Set once the day is over and has been summarized one last time.
+--                  Finalized days are skipped on subsequent ticks, which is what makes
+--                  backfilling previous days cheap enough to do on every tick.
+
+ALTER TABLE day_summaries ADD COLUMN IF NOT EXISTS content_hash    TEXT;
+ALTER TABLE day_summaries ADD COLUMN IF NOT EXISTS ai_generated_at TIMESTAMPTZ;
+ALTER TABLE day_summaries ADD COLUMN IF NOT EXISTS finalized       BOOLEAN NOT NULL DEFAULT FALSE;

--- a/server/migrations/0066_recall_capture_settings.sql
+++ b/server/migrations/0066_recall_capture_settings.sql
@@ -1,0 +1,59 @@
+-- Migration 0066: server-controlled Recall capture settings (global + per-agent).
+--
+-- Capture tunables lived only in `HistorySettings::default()` on the agent, so
+-- changing cadence or quality meant shipping a new agent build, and there was no way
+-- to stop one machine recording without uninstalling. The code even documented a
+-- server push that didn't exist ("A later phase adds a server-pushed per-agent
+-- disable").
+--
+-- Mirrors the retention tables: a single global row, plus optional per-agent
+-- overrides where NULL means "inherit the global value".
+--
+-- `enabled` is the operator kill switch. Agents apply it live, and cache the whole
+-- settings blob in local config so it survives restarts and reconnects.
+
+CREATE TABLE IF NOT EXISTS recall_settings_global (
+    id                  SMALLINT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    enabled             BOOLEAN NOT NULL DEFAULT TRUE,
+    -- Cadence while the user is active but not actively interacting (ms).
+    interval_ms         INTEGER NOT NULL DEFAULT 20000
+        CHECK (interval_ms BETWEEN 1000 AND 3600000),
+    -- Faster cadence while actively interacting (ms).
+    hot_interval_ms     INTEGER NOT NULL DEFAULT 6000
+        CHECK (hot_interval_ms BETWEEN 1000 AND 3600000),
+    -- JPEG quality of the stored keyframe (1-100). Low by design: these are review
+    -- thumbnails, not pixel-perfect archives.
+    jpeg_quality        SMALLINT NOT NULL DEFAULT 45
+        CHECK (jpeg_quality BETWEEN 1 AND 100),
+    -- Longest edge after downscale (px); 0 disables downscaling.
+    max_dim             INTEGER NOT NULL DEFAULT 1600
+        CHECK (max_dim = 0 OR max_dim BETWEEN 320 AND 7680),
+    -- Skip a frame whose average-hash is within this Hamming distance of the last
+    -- stored one. 0 = only skip byte-identical scenes.
+    dedup_hamming       SMALLINT NOT NULL DEFAULT 4
+        CHECK (dedup_hamming BETWEEN 0 AND 64),
+    -- Force a keyframe at least this often even if the screen looks unchanged, so the
+    -- timelapse has coverage and "the machine was on" is provable.
+    keyframe_max_gap_ms INTEGER NOT NULL DEFAULT 300000
+        CHECK (keyframe_max_gap_ms BETWEEN 10000 AND 86400000),
+    -- Run on-device OCR on each stored frame (makes screens searchable).
+    ocr                 BOOLEAN NOT NULL DEFAULT TRUE,
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO recall_settings_global (id) VALUES (1)
+    ON CONFLICT (id) DO NOTHING;
+
+-- Per-agent overrides. NULL in any column means "inherit the global value".
+CREATE TABLE IF NOT EXISTS recall_settings_agent (
+    agent_id            UUID PRIMARY KEY REFERENCES agents(id) ON DELETE CASCADE,
+    enabled             BOOLEAN,
+    interval_ms         INTEGER  CHECK (interval_ms IS NULL OR interval_ms BETWEEN 1000 AND 3600000),
+    hot_interval_ms     INTEGER  CHECK (hot_interval_ms IS NULL OR hot_interval_ms BETWEEN 1000 AND 3600000),
+    jpeg_quality        SMALLINT CHECK (jpeg_quality IS NULL OR jpeg_quality BETWEEN 1 AND 100),
+    max_dim             INTEGER  CHECK (max_dim IS NULL OR max_dim = 0 OR max_dim BETWEEN 320 AND 7680),
+    dedup_hamming       SMALLINT CHECK (dedup_hamming IS NULL OR dedup_hamming BETWEEN 0 AND 64),
+    keyframe_max_gap_ms INTEGER  CHECK (keyframe_max_gap_ms IS NULL OR keyframe_max_gap_ms BETWEEN 10000 AND 86400000),
+    ocr                 BOOLEAN,
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/server/migrations/0067_screen_frames_ocr_words.sql
+++ b/server/migrations/0067_screen_frames_ocr_words.sql
@@ -1,0 +1,18 @@
+-- Migration 0067: per-word OCR geometry, so replayed screens have selectable text.
+--
+-- The agent already ran on-device OCR on every keyframe, but only the flattened
+-- string was kept — enough to search for a frame, not enough to point at anything on
+-- it. Windows' OCR returns a bounding box per word; storing those lets the dashboard
+-- lay invisible, correctly-positioned spans over a replayed frame, so text on a
+-- screen from three weeks ago can be selected, copied, and clicked like a web page.
+--
+-- Shape: `[{"t": "word", "x": 0.12, "y": 0.34, "w": 0.05, "h": 0.02}, ...]` with
+-- coordinates normalized to 0..1 of the stored frame, so the overlay positions
+-- correctly at any rendered size without knowing the capture resolution.
+--
+-- Deliberately NOT indexed: this column is never queried, only fetched by frame id
+-- alongside the blob. Text search continues to use the `ocr_tsv` GIN index from 0060.
+-- Nullable because frames captured before this migration have no geometry, and
+-- because OCR can legitimately find nothing on a frame.
+
+ALTER TABLE screen_frames ADD COLUMN IF NOT EXISTS ocr_words JSONB;

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -180,6 +180,22 @@ pub fn router() -> Router<Arc<AppState>> {
             "/agents/:id/history/blob/:frame_id",
             get(screen_history::history_blob),
         )
+        .route(
+            "/agents/:id/history/text/:frame_id",
+            get(screen_history::history_frame_text),
+        )
+        // Recall capture tunables: global defaults + per-agent overrides.
+        .route(
+            "/settings/recall",
+            get(screen_history::recall_settings_get)
+                .put(screen_history::recall_settings_put),
+        )
+        .route(
+            "/agents/:id/history/settings",
+            get(screen_history::agent_recall_settings_get)
+                .put(screen_history::agent_recall_settings_put)
+                .delete(screen_history::agent_recall_settings_delete),
+        )
         .route("/agents/:id/wake", post(agents_telemetry::agent_wake))
         .route(
             "/agents/:id/software",

--- a/server/src/api/screen_history.rs
+++ b/server/src/api/screen_history.rs
@@ -4,12 +4,13 @@
 //! All endpoints are operator-gated for now. Phase 4 will add agent→user ownership
 //! so self-review users can see only their own machine.
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 
-use axum::extract::Extension;
+use axum::extract::{ConnectInfo, Extension};
 use axum::{
     extract::{Path, Query, State},
-    http::{header, StatusCode},
+    http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     Json,
 };
@@ -19,7 +20,46 @@ use uuid::Uuid;
 
 use crate::{auth, db, state::AppState};
 
-use super::helpers::err500;
+use super::helpers::{audit_ip, err500};
+
+// ── Audit actions ─────────────────────────────────────────────────────────────
+//
+// Replaying someone's screen history is the most privacy-sensitive capability in
+// the product, so every distinct kind of access is recorded against the operator
+// who performed it. Volume-heavy actions (frame listing, blob fetches) are
+// throttled to one row per viewing window by `should_audit_recall_access`;
+// searches are always logged individually because the *query text* is the part an
+// investigation actually needs.
+
+/// Timeline replay: listing frames, scrubbing, or fetching keyframe images.
+const AUDIT_REPLAY: &str = "recall_replay";
+/// OCR full-text search over an agent's captured screens.
+const AUDIT_SEARCH: &str = "recall_search";
+/// Reading the derived day narrative / activity segments.
+const AUDIT_DAY_VIEW: &str = "recall_day_view";
+
+/// Record a Recall access, collapsing continuous viewing into one row per window.
+async fn audit_recall(
+    s: &Arc<AppState>,
+    user: &auth::AuthUser,
+    agent_id: Uuid,
+    action: &'static str,
+    ip: Option<&str>,
+) {
+    if !s.should_audit_recall_access(user.user_id, agent_id, action) {
+        return;
+    }
+    db::insert_audit_log_traced(
+        &s.db,
+        user.username.as_str(),
+        Some(agent_id),
+        action,
+        "ok",
+        &serde_json::json!({ "role": user.role }),
+        ip,
+    )
+    .await;
+}
 
 /// Hard cap on frames returned in one range query (keeps the scrubber payload bounded).
 const MAX_FRAMES: i64 = 5_000;
@@ -96,6 +136,8 @@ pub async fn history_frames(
     Query(q): Query<FramesQuery>,
     State(s): State<Arc<AppState>>,
     Extension(user): Extension<auth::AuthUser>,
+    headers: HeaderMap,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
 ) -> Response {
     if !user.is_operator() {
         return forbidden();
@@ -104,6 +146,7 @@ pub async fn history_frames(
         Ok(v) => v,
         Err(msg) => return bad_request(msg),
     };
+    audit_recall(&s, &user, id, AUDIT_REPLAY, audit_ip(&headers, addr).as_deref()).await;
     let limit = q.limit.clamp(1, MAX_FRAMES);
     match db::list_screen_frames(&s.db, id, from, to, limit).await {
         Ok(frames) => Json(serde_json::json!({
@@ -128,10 +171,13 @@ pub async fn history_frame_at(
     Query(q): Query<FrameAtQuery>,
     State(s): State<Arc<AppState>>,
     Extension(user): Extension<auth::AuthUser>,
+    headers: HeaderMap,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
 ) -> Response {
     if !user.is_operator() {
         return forbidden();
     }
+    audit_recall(&s, &user, id, AUDIT_REPLAY, audit_ip(&headers, addr).as_deref()).await;
     let at = match q.at {
         None => Utc::now(),
         Some(s) => match DateTime::parse_from_rfc3339(s.trim()) {
@@ -164,6 +210,8 @@ pub async fn history_search(
     Query(q): Query<SearchQuery>,
     State(s): State<Arc<AppState>>,
     Extension(user): Extension<auth::AuthUser>,
+    headers: HeaderMap,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
 ) -> Response {
     if !user.is_operator() {
         return forbidden();
@@ -176,6 +224,18 @@ pub async fn history_search(
         Ok(v) => v,
         Err(msg) => return bad_request(msg),
     };
+    // Always logged, never throttled: unlike replay volume, *what* was searched for
+    // across someone's screen contents is exactly what an audit needs to show.
+    db::insert_audit_log_traced(
+        &s.db,
+        user.username.as_str(),
+        Some(id),
+        AUDIT_SEARCH,
+        "ok",
+        &serde_json::json!({ "role": user.role, "q": query }),
+        audit_ip(&headers, addr).as_deref(),
+    )
+    .await;
     let limit = q.limit.clamp(1, 500);
     match db::search_screen_frames(&s.db, id, query, from, to, limit).await {
         Ok(results) => Json(serde_json::json!({
@@ -238,15 +298,50 @@ pub struct DayQuery {
     day: Option<String>,
 }
 
-/// Parse the `day` param (UTC) into [start, end) instants, defaulting to today.
-fn parse_day(day: Option<String>) -> Result<(NaiveDate, DateTime<Utc>, DateTime<Utc>), &'static str> {
+/// Parse the `day` param into `[start, end)` instants **in `tz`**, defaulting to
+/// today in that zone.
+///
+/// The zone matters: a day is a local concept. Bucketing a UTC+8 user's activity by
+/// UTC days would put their 08:00–16:00 into one summary and 16:00–midnight into the
+/// next, and "today" would flip over at 08:00 local.
+///
+/// DST-safe: a local midnight that doesn't exist (spring-forward) resolves to the
+/// first valid instant after the gap, and an ambiguous one (fall-back) to the earlier
+/// of the two, so a range is always produced.
+fn parse_day_in_tz(
+    day: Option<String>,
+    tz: chrono_tz::Tz,
+) -> Result<(NaiveDate, DateTime<Utc>, DateTime<Utc>), &'static str> {
     let d = match day {
-        None => Utc::now().date_naive(),
+        None => Utc::now().with_timezone(&tz).date_naive(),
         Some(s) => NaiveDate::parse_from_str(s.trim(), "%Y-%m-%d")
             .map_err(|_| "invalid 'day' (expected YYYY-MM-DD)")?,
     };
-    let start = Utc.from_utc_datetime(&d.and_hms_opt(0, 0, 0).ok_or("invalid day")?);
-    Ok((d, start, start + Duration::days(1)))
+    let start = local_midnight(d, tz).ok_or("invalid day")?;
+    let end = d
+        .succ_opt()
+        .and_then(|next| local_midnight(next, tz))
+        .ok_or("invalid day")?;
+    Ok((d, start, end))
+}
+
+/// Midnight on `d` in `tz`, as a UTC instant. Resolves DST gaps forward and DST
+/// overlaps to the earlier instant rather than failing.
+fn local_midnight(d: NaiveDate, tz: chrono_tz::Tz) -> Option<DateTime<Utc>> {
+    use chrono::offset::LocalResult;
+    let naive = d.and_hms_opt(0, 0, 0)?;
+    match tz.from_local_datetime(&naive) {
+        LocalResult::Single(dt) => Some(dt.with_timezone(&Utc)),
+        LocalResult::Ambiguous(earlier, _) => Some(earlier.with_timezone(&Utc)),
+        // Spring-forward gap: local midnight doesn't exist. Step forward in
+        // 15-minute increments to the first instant that does.
+        LocalResult::None => (1..=8).find_map(|i| {
+            let shifted = naive + Duration::minutes(15 * i);
+            tz.from_local_datetime(&shifted)
+                .earliest()
+                .map(|dt| dt.with_timezone(&Utc))
+        }),
+    }
 }
 
 /// `GET /agents/:id/history/segments?day=YYYY-MM-DD` — activity segments for a day.
@@ -255,17 +350,22 @@ pub async fn history_segments(
     Query(q): Query<DayQuery>,
     State(s): State<Arc<AppState>>,
     Extension(user): Extension<auth::AuthUser>,
+    headers: HeaderMap,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
 ) -> Response {
     if !user.is_operator() {
         return forbidden();
     }
-    let (day, start, end) = match parse_day(q.day) {
+    audit_recall(&s, &user, id, AUDIT_DAY_VIEW, audit_ip(&headers, addr).as_deref()).await;
+    let tz = s.agent_timezone(id).await;
+    let (day, start, end) = match parse_day_in_tz(q.day, tz) {
         Ok(v) => v,
         Err(msg) => return bad_request(msg),
     };
     match db::list_activity_segments(&s.db, id, start, end).await {
         Ok(segments) => Json(serde_json::json!({
             "day": day.to_string(),
+            "timezone": tz.name(),
             "count": segments.len(),
             "segments": segments,
         }))
@@ -280,20 +380,317 @@ pub async fn history_day_summary(
     Query(q): Query<DayQuery>,
     State(s): State<Arc<AppState>>,
     Extension(user): Extension<auth::AuthUser>,
+    headers: HeaderMap,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
 ) -> Response {
     if !user.is_operator() {
         return forbidden();
     }
-    let (day, _start, _end) = match parse_day(q.day) {
+    audit_recall(&s, &user, id, AUDIT_DAY_VIEW, audit_ip(&headers, addr).as_deref()).await;
+    let tz = s.agent_timezone(id).await;
+    let (day, _start, _end) = match parse_day_in_tz(q.day, tz) {
         Ok(v) => v,
         Err(msg) => return bad_request(msg),
     };
     match db::get_day_summary(&s.db, id, day).await {
         Ok(summary) => Json(serde_json::json!({
             "day": day.to_string(),
+            "timezone": tz.name(),
             "summary": summary,
         }))
         .into_response(),
+        Err(e) => err500(e),
+    }
+}
+
+#[cfg(test)]
+mod day_tests {
+    use super::*;
+
+    fn day(s: &str, tz: chrono_tz::Tz) -> (DateTime<Utc>, DateTime<Utc>) {
+        let (_, start, end) = parse_day_in_tz(Some(s.to_string()), tz).unwrap();
+        (start, end)
+    }
+
+    #[test]
+    fn utc_day_is_midnight_to_midnight() {
+        let (start, end) = day("2026-08-08", chrono_tz::UTC);
+        assert_eq!(start.to_rfc3339(), "2026-08-08T00:00:00+00:00");
+        assert_eq!(end.to_rfc3339(), "2026-08-09T00:00:00+00:00");
+    }
+
+    #[test]
+    fn perth_day_starts_eight_hours_before_utc_midnight() {
+        // The bug this fixes: a UTC+8 user's day used to run 08:00–08:00 UTC-shifted.
+        let (start, end) = day("2026-08-08", chrono_tz::Australia::Perth);
+        assert_eq!(start.to_rfc3339(), "2026-08-07T16:00:00+00:00");
+        assert_eq!(end.to_rfc3339(), "2026-08-08T16:00:00+00:00");
+        assert_eq!((end - start).num_hours(), 24);
+    }
+
+    #[test]
+    fn western_zone_day_starts_after_utc_midnight() {
+        let (start, end) = day("2026-08-08", chrono_tz::America::New_York);
+        assert_eq!(start.to_rfc3339(), "2026-08-08T04:00:00+00:00");
+        assert_eq!(end.to_rfc3339(), "2026-08-09T04:00:00+00:00");
+    }
+
+    #[test]
+    fn spring_forward_day_is_23_hours_and_never_empty() {
+        // US DST starts 2026-03-08; the local day is 23h long.
+        let (start, end) = day("2026-03-08", chrono_tz::America::New_York);
+        assert!(start < end, "range must be non-empty across a DST gap");
+        assert_eq!((end - start).num_hours(), 23);
+    }
+
+    #[test]
+    fn fall_back_day_is_25_hours() {
+        // US DST ends 2026-11-01; the local day is 25h long.
+        let (start, end) = day("2026-11-01", chrono_tz::America::New_York);
+        assert_eq!((end - start).num_hours(), 25);
+    }
+
+    #[test]
+    fn midnight_gap_zone_still_resolves() {
+        // Lord Howe shifts by 30 minutes; exercise the gap-stepping path generally
+        // by asserting every day of a DST-transition week produces a valid range.
+        let tz = chrono_tz::Australia::Lord_Howe;
+        for d in 1..=7 {
+            let (start, end) = day(&format!("2026-10-0{d}"), tz);
+            assert!(start < end, "2026-10-0{d} produced an empty range");
+        }
+    }
+
+    #[test]
+    fn default_day_follows_the_zone_not_utc() {
+        // Whatever "now" is, the defaulted day must equal today *in that zone*.
+        let tz = chrono_tz::Pacific::Kiritimati; // UTC+14, maximally divergent.
+        let (d, _, _) = parse_day_in_tz(None, tz).unwrap();
+        assert_eq!(d, Utc::now().with_timezone(&tz).date_naive());
+    }
+
+    #[test]
+    fn rejects_malformed_day() {
+        assert!(parse_day_in_tz(Some("08/08/2026".into()), chrono_tz::UTC).is_err());
+        assert!(parse_day_in_tz(Some("2026-13-01".into()), chrono_tz::UTC).is_err());
+    }
+}
+
+// ── Capture settings administration ───────────────────────────────────────────
+
+/// Operator-supplied capture settings. Every field optional: omitted means "leave
+/// as-is" globally, or "inherit the global value" for a per-agent override.
+#[derive(Debug, Default, Deserialize, serde::Serialize)]
+pub struct RecallSettingsBody {
+    enabled: Option<bool>,
+    interval_ms: Option<i32>,
+    hot_interval_ms: Option<i32>,
+    jpeg_quality: Option<i16>,
+    max_dim: Option<i32>,
+    dedup_hamming: Option<i16>,
+    keyframe_max_gap_ms: Option<i32>,
+    ocr: Option<bool>,
+}
+
+/// Validate ranges before hitting the DB, so an out-of-range value returns a useful
+/// 400 rather than a 500 from a CHECK constraint violation.
+fn validate_settings(b: &RecallSettingsBody) -> Result<db::RecallSettingsPatch, &'static str> {
+    fn in_range<T: PartialOrd + Copy>(
+        v: Option<T>,
+        lo: T,
+        hi: T,
+        msg: &'static str,
+    ) -> Result<Option<T>, &'static str> {
+        match v {
+            Some(x) if x < lo || x > hi => Err(msg),
+            other => Ok(other),
+        }
+    }
+
+    Ok(db::RecallSettingsPatch {
+        enabled: b.enabled,
+        interval_ms: in_range(
+            b.interval_ms,
+            1_000,
+            3_600_000,
+            "interval_ms must be 1000–3600000",
+        )?,
+        hot_interval_ms: in_range(
+            b.hot_interval_ms,
+            1_000,
+            3_600_000,
+            "hot_interval_ms must be 1000–3600000",
+        )?,
+        jpeg_quality: in_range(b.jpeg_quality, 1, 100, "jpeg_quality must be 1–100")?,
+        // 0 is the documented "don't downscale" sentinel, so it bypasses the range.
+        max_dim: match b.max_dim {
+            Some(0) | None => b.max_dim,
+            Some(x) if (320..=7680).contains(&x) => Some(x),
+            Some(_) => return Err("max_dim must be 0 (no downscale) or 320–7680"),
+        },
+        dedup_hamming: in_range(b.dedup_hamming, 0, 64, "dedup_hamming must be 0–64")?,
+        keyframe_max_gap_ms: in_range(
+            b.keyframe_max_gap_ms,
+            10_000,
+            86_400_000,
+            "keyframe_max_gap_ms must be 10000–86400000",
+        )?,
+        ocr: b.ocr,
+    })
+}
+
+/// `GET /settings/recall` — global capture settings.
+pub async fn recall_settings_get(
+    State(s): State<Arc<AppState>>,
+    Extension(user): Extension<auth::AuthUser>,
+) -> Response {
+    if !user.is_operator() {
+        return forbidden();
+    }
+    match db::get_recall_settings_global(&s.db).await {
+        Ok(v) => Json(v).into_response(),
+        Err(e) => err500(e),
+    }
+}
+
+/// `PUT /settings/recall` — change global capture settings (admin only).
+///
+/// Admin-gated: this controls how much every machine in the fleet records, and
+/// includes the kill switch.
+pub async fn recall_settings_put(
+    State(s): State<Arc<AppState>>,
+    Extension(user): Extension<auth::AuthUser>,
+    headers: HeaderMap,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    Json(body): Json<RecallSettingsBody>,
+) -> Response {
+    if !user.is_admin() {
+        return forbidden();
+    }
+    let patch = match validate_settings(&body) {
+        Ok(p) => p,
+        Err(msg) => return bad_request(msg),
+    };
+    if let Err(e) = db::set_recall_settings_global(&s.db, &patch).await {
+        return err500(e);
+    }
+    db::insert_audit_log_traced(
+        &s.db,
+        user.username.as_str(),
+        None,
+        "recall_settings_global",
+        "ok",
+        &serde_json::to_value(&body).unwrap_or_else(|_| serde_json::json!({})),
+        audit_ip(&headers, addr).as_deref(),
+    )
+    .await;
+    crate::ws_agent::push_recall_settings_to_all_connected(&s).await;
+    recall_settings_get(State(s.clone()), Extension(user)).await
+}
+
+/// `GET /agents/:id/history/settings` — the settings this agent actually runs with.
+pub async fn agent_recall_settings_get(
+    Path(id): Path<Uuid>,
+    State(s): State<Arc<AppState>>,
+    Extension(user): Extension<auth::AuthUser>,
+) -> Response {
+    if !user.is_operator() {
+        return forbidden();
+    }
+    match db::effective_recall_settings(&s.db, id).await {
+        Ok(v) => Json(v).into_response(),
+        Err(e) => err500(e),
+    }
+}
+
+/// `PUT /agents/:id/history/settings` — per-agent override (admin only).
+///
+/// Omitted fields become NULL, i.e. that field inherits the global value again.
+pub async fn agent_recall_settings_put(
+    Path(id): Path<Uuid>,
+    State(s): State<Arc<AppState>>,
+    Extension(user): Extension<auth::AuthUser>,
+    headers: HeaderMap,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    Json(body): Json<RecallSettingsBody>,
+) -> Response {
+    if !user.is_admin() {
+        return forbidden();
+    }
+    let patch = match validate_settings(&body) {
+        Ok(p) => p,
+        Err(msg) => return bad_request(msg),
+    };
+    if let Err(e) = db::set_recall_settings_agent(&s.db, id, &patch).await {
+        return err500(e);
+    }
+    db::insert_audit_log_traced(
+        &s.db,
+        user.username.as_str(),
+        Some(id),
+        "recall_settings_agent",
+        "ok",
+        &serde_json::to_value(&body).unwrap_or_else(|_| serde_json::json!({})),
+        audit_ip(&headers, addr).as_deref(),
+    )
+    .await;
+    crate::ws_agent::push_recall_settings_to_agent(&s, id).await;
+    agent_recall_settings_get(Path(id), State(s.clone()), Extension(user)).await
+}
+
+/// `DELETE /agents/:id/history/settings` — drop the override, inherit global again.
+pub async fn agent_recall_settings_delete(
+    Path(id): Path<Uuid>,
+    State(s): State<Arc<AppState>>,
+    Extension(user): Extension<auth::AuthUser>,
+    headers: HeaderMap,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+) -> Response {
+    if !user.is_admin() {
+        return forbidden();
+    }
+    if let Err(e) = db::clear_recall_settings_agent(&s.db, id).await {
+        return err500(e);
+    }
+    db::insert_audit_log_traced(
+        &s.db,
+        user.username.as_str(),
+        Some(id),
+        "recall_settings_agent_clear",
+        "ok",
+        &serde_json::json!({}),
+        audit_ip(&headers, addr).as_deref(),
+    )
+    .await;
+    crate::ws_agent::push_recall_settings_to_agent(&s, id).await;
+    Json(serde_json::json!({ "ok": true })).into_response()
+}
+
+/// `GET /agents/:id/history/text/:frame_id` — OCR text + word boxes for one frame.
+///
+/// Powers the selectable-text overlay: word boxes are normalized to 0..1 of the
+/// frame, so the dashboard can position invisible spans over the replayed image at
+/// whatever size it happens to be rendered.
+pub async fn history_frame_text(
+    Path((id, frame_id)): Path<(Uuid, i64)>,
+    State(s): State<Arc<AppState>>,
+    Extension(user): Extension<auth::AuthUser>,
+    headers: HeaderMap,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+) -> Response {
+    if !user.is_operator() {
+        return forbidden();
+    }
+    // Reading the text off a frame is the same act as looking at it, so it shares
+    // the replay audit action (and its throttle).
+    audit_recall(&s, &user, id, AUDIT_REPLAY, audit_ip(&headers, addr).as_deref()).await;
+    match db::screen_frame_text(&s.db, id, frame_id).await {
+        Ok(Some(v)) => (
+            [(header::CACHE_CONTROL, "private, max-age=86400")],
+            Json(v),
+        )
+            .into_response(),
+        Ok(None) => (StatusCode::NOT_FOUND, "No such frame").into_response(),
         Err(e) => err500(e),
     }
 }
@@ -303,10 +700,14 @@ pub async fn history_blob(
     Path((id, frame_id)): Path<(Uuid, i64)>,
     State(s): State<Arc<AppState>>,
     Extension(user): Extension<auth::AuthUser>,
+    headers: HeaderMap,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
 ) -> Response {
     if !user.is_operator() {
         return forbidden();
     }
+    // Throttled: one replay row per viewing window, not one per keyframe rendered.
+    audit_recall(&s, &user, id, AUDIT_REPLAY, audit_ip(&headers, addr).as_deref()).await;
     let blob_ref = match db::screen_frame_blob_ref(&s.db, id, frame_id).await {
         Ok(Some(r)) => r,
         Ok(None) => {

--- a/server/src/db/agents.rs
+++ b/server/src/db/agents.rs
@@ -732,6 +732,22 @@ pub async fn upsert_agent_info(
     Ok(())
 }
 
+/// The agent's self-reported IANA timezone (e.g. `Australia/Perth`), if it sent one.
+///
+/// Recall buckets activity into *days*, and a day only means something in a local
+/// timezone: bucketing a UTC+8 user's activity by UTC days puts their morning in
+/// yesterday's summary and splits every real day across two rows. Agents report this
+/// in `agent_info`; older agents that don't are handled by the caller's fallback.
+pub async fn agent_timezone(pool: &PgPool, agent_id: Uuid) -> Result<Option<String>> {
+    let tz: Option<String> =
+        sqlx::query_scalar("SELECT info->>'timezone' FROM agent_info WHERE agent_id = $1")
+            .bind(agent_id)
+            .fetch_optional(pool)
+            .await?
+            .flatten();
+    Ok(tz.filter(|s| !s.trim().is_empty()))
+}
+
 /// Returns `info` with a `monitors` array carried over from the stored snapshot
 /// when the incoming one has no non-empty list. Returns `info` unchanged when it
 /// already carries monitors or there's nothing to preserve.

--- a/server/src/db/narrative.rs
+++ b/server/src/db/narrative.rs
@@ -152,36 +152,89 @@ pub async fn replace_activity_segments(
     Ok(())
 }
 
-/// Upsert the per-day summary for an agent.
-#[allow(clippy::too_many_arguments)]
-pub async fn upsert_day_summary(
+/// What the worker needs to decide whether a day is worth rebuilding.
+#[derive(Debug, Clone, Default)]
+pub struct DaySummaryState {
+    /// Fingerprint of the segments the stored summary was built from.
+    pub content_hash: Option<String>,
+    /// When the vision narrative was last generated (rate-limits AI independently).
+    pub ai_generated_at: Option<DateTime<Utc>>,
+    /// Day is over and has had its final summarization pass.
+    pub finalized: bool,
+    /// Whether a narrative is stored at all.
+    pub has_narrative: bool,
+}
+
+/// Incremental-rebuild state for one (agent, day). Absent row => never summarized.
+pub async fn day_summary_state(
     pool: &PgPool,
     agent_id: Uuid,
     day: NaiveDate,
-    narrative: &str,
-    totals: &serde_json::Value,
-    top_apps: &serde_json::Value,
-    highlights: &serde_json::Value,
-    source: &str,
-) -> Result<()> {
+) -> Result<Option<DaySummaryState>> {
+    let row = sqlx::query(
+        "SELECT content_hash, ai_generated_at, finalized,
+                (narrative IS NOT NULL AND length(narrative) > 0) AS has_narrative
+         FROM day_summaries WHERE agent_id = $1 AND day = $2",
+    )
+    .bind(agent_id)
+    .bind(day)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|r| DaySummaryState {
+        content_hash: r.try_get("content_hash").unwrap_or(None),
+        ai_generated_at: r.try_get("ai_generated_at").unwrap_or(None),
+        finalized: r.try_get("finalized").unwrap_or(false),
+        has_narrative: r.try_get("has_narrative").unwrap_or(false),
+    }))
+}
+
+/// Fields written by one summarization pass.
+pub struct DaySummaryWrite<'a> {
+    pub agent_id: Uuid,
+    pub day: NaiveDate,
+    pub narrative: &'a str,
+    pub totals: &'a serde_json::Value,
+    pub top_apps: &'a serde_json::Value,
+    pub highlights: &'a serde_json::Value,
+    pub source: &'a str,
+    pub content_hash: &'a str,
+    /// `true` when this pass produced a fresh AI narrative (stamps `ai_generated_at`).
+    pub ai_refreshed: bool,
+    /// `true` once the day is over and this is its last pass.
+    pub finalized: bool,
+}
+
+/// Upsert the per-day summary for an agent.
+pub async fn upsert_day_summary(pool: &PgPool, w: DaySummaryWrite<'_>) -> Result<()> {
     sqlx::query(
-        "INSERT INTO day_summaries (agent_id, day, narrative, totals, top_apps, highlights, source, updated_at)
-         VALUES ($1,$2,$3,$4,$5,$6,$7, NOW())
+        "INSERT INTO day_summaries
+           (agent_id, day, narrative, totals, top_apps, highlights, source,
+            content_hash, ai_generated_at, finalized, updated_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,
+                 CASE WHEN $9 THEN NOW() ELSE NULL END, $10, NOW())
          ON CONFLICT (agent_id, day) DO UPDATE SET
            narrative = EXCLUDED.narrative,
            totals = EXCLUDED.totals,
            top_apps = EXCLUDED.top_apps,
            highlights = EXCLUDED.highlights,
            source = EXCLUDED.source,
+           content_hash = EXCLUDED.content_hash,
+           -- Keep the previous stamp when this pass reused the existing narrative,
+           -- so the AI rate-limit measures time since the last *real* AI call.
+           ai_generated_at = CASE WHEN $9 THEN NOW() ELSE day_summaries.ai_generated_at END,
+           finalized = EXCLUDED.finalized,
            updated_at = NOW()",
     )
-    .bind(agent_id)
-    .bind(day)
-    .bind(narrative)
-    .bind(totals)
-    .bind(top_apps)
-    .bind(highlights)
-    .bind(source)
+    .bind(w.agent_id)
+    .bind(w.day)
+    .bind(w.narrative)
+    .bind(w.totals)
+    .bind(w.top_apps)
+    .bind(w.highlights)
+    .bind(w.source)
+    .bind(w.content_hash)
+    .bind(w.ai_refreshed)
+    .bind(w.finalized)
     .execute(pool)
     .await?;
     Ok(())

--- a/server/src/db/screen_history.rs
+++ b/server/src/db/screen_history.rs
@@ -47,7 +47,12 @@ pub async fn ensure_screen_frame_partition(pool: &PgPool, day: NaiveDate) -> Res
     Ok(())
 }
 
-/// Insert one keyframe index row; returns the new global frame id.
+/// Insert one keyframe index row.
+///
+/// Returns `Some(id)` for a newly stored frame, or `None` when `client_uid` matches
+/// a frame already stored — the agent re-sent it because an ack was lost. Callers
+/// treat `None` as success (and should delete the now-redundant blob they just
+/// wrote), since the frame *is* durably persisted either way.
 #[allow(clippy::too_many_arguments)]
 pub async fn insert_screen_frame(
     pool: &PgPool,
@@ -59,16 +64,21 @@ pub async fn insert_screen_frame(
     phash: i64,
     blob_ref: &str,
     ocr_text: Option<&str>,
-) -> Result<i64> {
+    ocr_words: Option<&serde_json::Value>,
+    client_uid: Option<Uuid>,
+) -> Result<Option<i64>> {
     // Ensure the day partition first; ignore errors (DEFAULT partition is the fallback).
     if let Err(e) = ensure_screen_frame_partition(pool, captured_at.date_naive()).await {
         tracing::warn!(error = %e, "ensure_screen_frame_partition failed; using DEFAULT partition");
     }
     // ocr_tsv is computed here (not a generated column) since to_tsvector is only STABLE.
-    let id: i64 = sqlx::query_scalar(
+    // ON CONFLICT makes the agent's at-least-once retry idempotent (migration 0063).
+    let id: Option<i64> = sqlx::query_scalar(
         "INSERT INTO screen_frames
-           (agent_id, captured_at, monitor, w, h, phash, blob_ref, ocr_text, ocr_tsv)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8, to_tsvector('english', coalesce($8, '')))
+           (agent_id, captured_at, monitor, w, h, phash, blob_ref, ocr_text, ocr_tsv,
+            client_uid, ocr_words)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8, to_tsvector('english', coalesce($8, '')), $9, $10)
+         ON CONFLICT (captured_at, client_uid) DO NOTHING
          RETURNING id",
     )
     .bind(agent_id)
@@ -79,7 +89,9 @@ pub async fn insert_screen_frame(
     .bind(phash)
     .bind(blob_ref)
     .bind(ocr_text)
-    .fetch_one(pool)
+    .bind(client_uid)
+    .bind(ocr_words)
+    .fetch_optional(pool)
     .await?;
     Ok(id)
 }
@@ -255,6 +267,188 @@ pub async fn search_screen_frames(
         .collect())
 }
 
+// ── Capture settings ──────────────────────────────────────────────────────────
+
+/// Effective capture settings for one agent: the global row with any per-agent
+/// override applied column-by-column (`COALESCE`, so NULL means "inherit").
+///
+/// Returned as the JSON the agent consumes directly, so there is exactly one place
+/// that knows the field names on the wire.
+pub async fn effective_recall_settings(
+    pool: &PgPool,
+    agent_id: Uuid,
+) -> Result<serde_json::Value> {
+    let row = sqlx::query(
+        "SELECT
+           COALESCE(a.enabled,             g.enabled)             AS enabled,
+           COALESCE(a.interval_ms,         g.interval_ms)         AS interval_ms,
+           COALESCE(a.hot_interval_ms,     g.hot_interval_ms)     AS hot_interval_ms,
+           COALESCE(a.jpeg_quality,        g.jpeg_quality)        AS jpeg_quality,
+           COALESCE(a.max_dim,             g.max_dim)             AS max_dim,
+           COALESCE(a.dedup_hamming,       g.dedup_hamming)       AS dedup_hamming,
+           COALESCE(a.keyframe_max_gap_ms, g.keyframe_max_gap_ms) AS keyframe_max_gap_ms,
+           COALESCE(a.ocr,                 g.ocr)                 AS ocr
+         FROM recall_settings_global g
+         LEFT JOIN recall_settings_agent a ON a.agent_id = $1
+         WHERE g.id = 1",
+    )
+    .bind(agent_id)
+    .fetch_optional(pool)
+    .await?;
+
+    let Some(r) = row else {
+        // Global row missing (migration not applied): let the agent keep its built-in
+        // defaults rather than pushing a half-formed policy.
+        return Ok(serde_json::Value::Null);
+    };
+    Ok(serde_json::json!({
+        "enabled": r.try_get::<bool, _>("enabled").unwrap_or(true),
+        "interval_ms": r.try_get::<i32, _>("interval_ms").unwrap_or(20_000),
+        "hot_interval_ms": r.try_get::<i32, _>("hot_interval_ms").unwrap_or(6_000),
+        "jpeg_quality": r.try_get::<i16, _>("jpeg_quality").unwrap_or(45),
+        "max_dim": r.try_get::<i32, _>("max_dim").unwrap_or(1_600),
+        "dedup_hamming": r.try_get::<i16, _>("dedup_hamming").unwrap_or(4),
+        "keyframe_max_gap_ms": r.try_get::<i32, _>("keyframe_max_gap_ms").unwrap_or(300_000),
+        "ocr": r.try_get::<bool, _>("ocr").unwrap_or(true),
+    }))
+}
+
+/// The raw global capture settings row (for the settings UI).
+pub async fn get_recall_settings_global(pool: &PgPool) -> Result<serde_json::Value> {
+    let r = sqlx::query(
+        "SELECT enabled, interval_ms, hot_interval_ms, jpeg_quality, max_dim,
+                dedup_hamming, keyframe_max_gap_ms, ocr
+         FROM recall_settings_global WHERE id = 1",
+    )
+    .fetch_one(pool)
+    .await?;
+    Ok(serde_json::json!({
+        "enabled": r.try_get::<bool, _>("enabled").unwrap_or(true),
+        "interval_ms": r.try_get::<i32, _>("interval_ms").unwrap_or(20_000),
+        "hot_interval_ms": r.try_get::<i32, _>("hot_interval_ms").unwrap_or(6_000),
+        "jpeg_quality": r.try_get::<i16, _>("jpeg_quality").unwrap_or(45),
+        "max_dim": r.try_get::<i32, _>("max_dim").unwrap_or(1_600),
+        "dedup_hamming": r.try_get::<i16, _>("dedup_hamming").unwrap_or(4),
+        "keyframe_max_gap_ms": r.try_get::<i32, _>("keyframe_max_gap_ms").unwrap_or(300_000),
+        "ocr": r.try_get::<bool, _>("ocr").unwrap_or(true),
+    }))
+}
+
+/// Capture settings the operator may change. `None` leaves a column untouched.
+#[derive(Debug, Default, Clone)]
+pub struct RecallSettingsPatch {
+    pub enabled: Option<bool>,
+    pub interval_ms: Option<i32>,
+    pub hot_interval_ms: Option<i32>,
+    pub jpeg_quality: Option<i16>,
+    pub max_dim: Option<i32>,
+    pub dedup_hamming: Option<i16>,
+    pub keyframe_max_gap_ms: Option<i32>,
+    pub ocr: Option<bool>,
+}
+
+/// Update the global capture settings. Omitted fields keep their current value.
+pub async fn set_recall_settings_global(pool: &PgPool, p: &RecallSettingsPatch) -> Result<()> {
+    sqlx::query(
+        "UPDATE recall_settings_global SET
+           enabled             = COALESCE($1, enabled),
+           interval_ms         = COALESCE($2, interval_ms),
+           hot_interval_ms     = COALESCE($3, hot_interval_ms),
+           jpeg_quality        = COALESCE($4, jpeg_quality),
+           max_dim             = COALESCE($5, max_dim),
+           dedup_hamming       = COALESCE($6, dedup_hamming),
+           keyframe_max_gap_ms = COALESCE($7, keyframe_max_gap_ms),
+           ocr                 = COALESCE($8, ocr),
+           updated_at          = NOW()
+         WHERE id = 1",
+    )
+    .bind(p.enabled)
+    .bind(p.interval_ms)
+    .bind(p.hot_interval_ms)
+    .bind(p.jpeg_quality)
+    .bind(p.max_dim)
+    .bind(p.dedup_hamming)
+    .bind(p.keyframe_max_gap_ms)
+    .bind(p.ocr)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Set (or clear) the per-agent override. Fields left `None` become NULL, i.e. the
+/// agent inherits the global value for them.
+pub async fn set_recall_settings_agent(
+    pool: &PgPool,
+    agent_id: Uuid,
+    p: &RecallSettingsPatch,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO recall_settings_agent
+           (agent_id, enabled, interval_ms, hot_interval_ms, jpeg_quality, max_dim,
+            dedup_hamming, keyframe_max_gap_ms, ocr, updated_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9, NOW())
+         ON CONFLICT (agent_id) DO UPDATE SET
+           enabled = EXCLUDED.enabled,
+           interval_ms = EXCLUDED.interval_ms,
+           hot_interval_ms = EXCLUDED.hot_interval_ms,
+           jpeg_quality = EXCLUDED.jpeg_quality,
+           max_dim = EXCLUDED.max_dim,
+           dedup_hamming = EXCLUDED.dedup_hamming,
+           keyframe_max_gap_ms = EXCLUDED.keyframe_max_gap_ms,
+           ocr = EXCLUDED.ocr,
+           updated_at = NOW()",
+    )
+    .bind(agent_id)
+    .bind(p.enabled)
+    .bind(p.interval_ms)
+    .bind(p.hot_interval_ms)
+    .bind(p.jpeg_quality)
+    .bind(p.max_dim)
+    .bind(p.dedup_hamming)
+    .bind(p.keyframe_max_gap_ms)
+    .bind(p.ocr)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Remove an agent's override so it fully inherits the global settings again.
+pub async fn clear_recall_settings_agent(pool: &PgPool, agent_id: Uuid) -> Result<()> {
+    sqlx::query("DELETE FROM recall_settings_agent WHERE agent_id = $1")
+        .bind(agent_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// OCR text plus per-word geometry for one frame owned by `agent_id`.
+///
+/// Fetched on demand for the frame currently on screen rather than included in the
+/// range listing: a 3000-frame scrub would otherwise carry every word box on every
+/// frame, which dwarfs the metadata it's attached to.
+pub async fn screen_frame_text(
+    pool: &PgPool,
+    agent_id: Uuid,
+    id: i64,
+) -> Result<Option<serde_json::Value>> {
+    let row = sqlx::query(
+        "SELECT ocr_text, ocr_words FROM screen_frames WHERE id = $1 AND agent_id = $2",
+    )
+    .bind(id)
+    .bind(agent_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|r| {
+        serde_json::json!({
+            "text": r.try_get::<Option<String>, _>("ocr_text").unwrap_or(None),
+            "words": r
+                .try_get::<Option<serde_json::Value>, _>("ocr_words")
+                .unwrap_or(None)
+                .unwrap_or_else(|| serde_json::json!([])),
+        })
+    }))
+}
+
 /// The blob path (relative to `SCREEN_HISTORY_DIR`) for a frame owned by `agent_id`.
 /// Scoped by agent so the blob endpoint can't be used to enumerate other agents' frames.
 pub async fn screen_frame_blob_ref(
@@ -271,13 +465,25 @@ pub async fn screen_frame_blob_ref(
     Ok(v)
 }
 
-/// Distinct agent ids that have recorded at least one screen-history frame. Used to
-/// filter the Recall device picker down to agents that actually have history, rather
-/// than every enrolled fleet agent.
+/// How far back the device picker looks for "has any Recall history".
+///
+/// Bounded on purpose: an unbounded `SELECT DISTINCT agent_id` scans *every* day
+/// partition on every page load, and this is the highest-cardinality table in the
+/// schema. A predicate on the partition key lets Postgres prune to recent
+/// partitions instead. An agent with nothing in this window has nothing worth
+/// scrubbing anyway.
+const DEVICE_LIST_LOOKBACK_DAYS: i64 = 30;
+
+/// Distinct agent ids that recorded at least one screen-history frame recently. Used
+/// to filter the Recall device picker down to agents that actually have history,
+/// rather than every enrolled fleet agent.
 pub async fn list_agents_with_screen_history(pool: &PgPool) -> Result<Vec<Uuid>> {
-    let ids: Vec<Uuid> = sqlx::query_scalar("SELECT DISTINCT agent_id FROM screen_frames")
-        .fetch_all(pool)
-        .await?;
+    let since = Utc::now() - Duration::days(DEVICE_LIST_LOOKBACK_DAYS);
+    let ids: Vec<Uuid> =
+        sqlx::query_scalar("SELECT DISTINCT agent_id FROM screen_frames WHERE captured_at >= $1")
+            .bind(since)
+            .fetch_all(pool)
+            .await?;
     Ok(ids)
 }
 

--- a/server/src/screen_narrative.rs
+++ b/server/src/screen_narrative.rs
@@ -1,16 +1,32 @@
-//! Screen-history day-narrative worker (Phase 3).
+//! Screen-history day-narrative worker.
 //!
-//! Every ~15 min it rebuilds today's `activity_segments` + `day_summaries` for each
-//! agent with recent keyframes, by segmenting `window_events` and categorizing by
-//! app/title (rule-based baseline). When an OpenAI-compatible provider is configured
+//! Every ~15 min it refreshes `activity_segments` + `day_summaries` for each agent
+//! with recent keyframes, by segmenting `window_events` and categorizing by app/title
+//! (rule-based baseline). When an OpenAI-compatible provider is configured
 //! (`SCREEN_HISTORY_AI_*`), it additionally asks a vision model for a natural-language
 //! narrative, sampling a few keyframes; any failure falls back to the rule-based text.
+//!
+//! Work is **incremental**, which matters because the naive version re-derived every
+//! agent's whole day — vision call included — on every tick:
+//!
+//! * Each agent's local day is fingerprinted from its segments. An unchanged
+//!   fingerprint means the tick would produce an identical summary, so it is skipped.
+//! * Vision calls are rate-limited per agent-day ([`AI_MIN_INTERVAL`]) rather than
+//!   running once per tick, with one guaranteed final call once the day closes.
+//! * Days are `finalized` when their window closes, after which they're skipped on a
+//!   single cheap read — which is what makes re-checking the previous
+//!   [`BACKFILL_DAYS`] on every tick affordable. That backfill exists so a day whose
+//!   final hours were missed (restart at midnight, agent offline at day end) gets
+//!   completed instead of staying silently truncated.
+//! * Agents are processed with bounded concurrency so one slow provider call can't
+//!   stall the rest of the fleet behind it.
 
 use std::sync::Arc;
 use std::time::Duration;
 
 use base64::Engine as _;
 use chrono::{DateTime, Utc};
+use futures_util::stream::{FuturesUnordered, StreamExt as _};
 use tracing::{debug, info, warn};
 
 use crate::config::ScreenHistoryAi;
@@ -26,6 +42,18 @@ const MERGE_GAP_SECS: i64 = 5 * 60;
 const MIN_SEGMENT_SECS: i64 = 20;
 /// Max keyframes attached to the AI vision call.
 const AI_MAX_IMAGES: usize = 4;
+/// How many days back to look for unfinalized summaries on each tick. Covers a
+/// server restart or an agent that was offline over a day boundary.
+const BACKFILL_DAYS: i64 = 2;
+/// Agents summarized concurrently. Keeps one slow vision call from stalling the
+/// fleet without opening an HTTP request per agent at once.
+const MAX_CONCURRENT_AGENTS: usize = 4;
+/// Minimum spacing between vision-model calls for the *same* agent-day.
+///
+/// Without this the worker re-narrated each in-progress day on every 15-minute tick,
+/// so the AI cost of one day grew with the number of ticks in it. The cheap
+/// rule-based rebuild still runs on every tick, so segments and totals stay live.
+const AI_MIN_INTERVAL: chrono::Duration = chrono::Duration::minutes(90);
 
 pub fn spawn(state: Arc<AppState>) {
     tokio::spawn(async move {
@@ -44,20 +72,75 @@ pub fn spawn(state: Arc<AppState>) {
 
 async fn run_once(state: &Arc<AppState>) -> anyhow::Result<()> {
     let now = Utc::now();
-    let today = now.date_naive();
-    let day_start = Utc.from_utc_datetime(&today.and_hms_opt(0, 0, 0).unwrap());
-    // Only summarize up to "now" for today.
-    let agents = db::agents_with_frames_between(&state.db, day_start, now).await?;
+    // Wide enough to cover every timezone's "recent days" (UTC-12..UTC+14) plus the
+    // backfill window, so an agent in any zone is picked up as a candidate. The
+    // per-agent local days are then computed below in that agent's own zone.
+    let scan_from = now - chrono::Duration::hours(24 * (BACKFILL_DAYS + 2));
+    let agents = db::agents_with_frames_between(&state.db, scan_from, now).await?;
     if agents.is_empty() {
         return Ok(());
     }
-    debug!(count = agents.len(), "screen-narrative: summarizing agents for today");
-    for agent_id in agents {
-        if let Err(e) = summarize_agent_day(state, agent_id, day_start, now).await {
-            warn!(%agent_id, "screen-narrative: agent summary failed: {e}");
+    debug!(count = agents.len(), "screen-narrative: summarizing agents");
+
+    // Bounded concurrency: one agent with a slow vision call must not delay every
+    // other agent's summary behind it, but an unbounded fan-out would open a
+    // connection and an HTTP request per agent at once.
+    let mut pending = agents.into_iter();
+    let mut in_flight = FuturesUnordered::new();
+    loop {
+        while in_flight.len() < MAX_CONCURRENT_AGENTS {
+            let Some(agent_id) = pending.next() else { break };
+            in_flight.push(summarize_agent(state, agent_id, now));
+        }
+        if in_flight.next().await.is_none() {
+            break;
         }
     }
     Ok(())
+}
+
+/// Summarize every candidate local day for one agent (today, plus recent days that
+/// were never finalized).
+async fn summarize_agent(state: &Arc<AppState>, agent_id: uuid::Uuid, now: DateTime<Utc>) {
+    let tz = state.agent_timezone(agent_id).await;
+    // The agent's *local* today. Summarizing a UTC day would give anyone east or west
+    // of UTC a "day" that starts mid-morning and spans two calendar dates.
+    let local_today = now.with_timezone(&tz).date_naive();
+
+    // Walk backwards from today. Previous days are almost always already finalized,
+    // in which case `summarize_agent_day` returns after a single cheap state read —
+    // that's what makes backfilling affordable on every tick. It exists so a day
+    // whose final hours were missed (server restart at midnight, agent offline at
+    // day end) gets completed rather than being silently truncated forever.
+    for back in 0..=BACKFILL_DAYS {
+        let Some(day) = local_today.checked_sub_signed(chrono::Duration::days(back)) else {
+            continue;
+        };
+        let Some(day_start) = local_midnight_utc(day, tz) else {
+            warn!(%agent_id, %day, "screen-narrative: could not resolve local midnight; skipping");
+            continue;
+        };
+        if let Err(e) = summarize_agent_day(state, agent_id, day, day_start, now, tz).await {
+            warn!(%agent_id, %day, "screen-narrative: agent summary failed: {e}");
+        }
+    }
+}
+
+/// Midnight on `d` in `tz` as a UTC instant, resolving DST gaps forward and DST
+/// overlaps to the earlier instant. Mirrors the API's `local_midnight` so the
+/// worker writes exactly the day rows the read path asks for.
+fn local_midnight_utc(d: chrono::NaiveDate, tz: chrono_tz::Tz) -> Option<DateTime<Utc>> {
+    use chrono::offset::LocalResult;
+    let naive = d.and_hms_opt(0, 0, 0)?;
+    match tz.from_local_datetime(&naive) {
+        LocalResult::Single(dt) => Some(dt.with_timezone(&Utc)),
+        LocalResult::Ambiguous(earlier, _) => Some(earlier.with_timezone(&Utc)),
+        LocalResult::None => (1..=8).find_map(|i| {
+            tz.from_local_datetime(&(naive + chrono::Duration::minutes(15 * i)))
+                .earliest()
+                .map(|dt| dt.with_timezone(&Utc))
+        }),
+    }
 }
 
 use chrono::TimeZone as _;
@@ -65,47 +148,122 @@ use chrono::TimeZone as _;
 async fn summarize_agent_day(
     state: &Arc<AppState>,
     agent_id: uuid::Uuid,
+    local_day: chrono::NaiveDate,
     day_start: DateTime<Utc>,
     now: DateTime<Utc>,
+    tz: chrono_tz::Tz,
 ) -> anyhow::Result<()> {
-    let day_end = day_start + chrono::Duration::days(1);
-    let focus = db::window_events_for_range(&state.db, agent_id, day_start, now).await?;
-    let segments = build_segments(&focus, now);
+    // Local, not `day_start + 24h`: a DST transition makes the local day 23 or 25
+    // hours long, and using a fixed 24h window would leak an hour into the next day.
+    let day_end = local_day
+        .succ_opt()
+        .and_then(|next| local_midnight_utc(next, tz))
+        .unwrap_or(day_start + chrono::Duration::days(1));
+
+    let state_row = db::day_summary_state(&state.db, agent_id, local_day).await?;
+    let day_is_over = now >= day_end;
+
+    // A finalized day is immutable: its window has closed and it has had its last
+    // pass. Skipping here after one cheap read is what makes backfilling every tick
+    // affordable.
+    if state_row.as_ref().is_some_and(|s| s.finalized) {
+        return Ok(());
+    }
+
+    // Only summarize up to "now" — a day still in progress has no events past it.
+    let upper = day_end.min(now);
+    let focus = db::window_events_for_range(&state.db, agent_id, day_start, upper).await?;
+    let segments = build_segments(&focus, upper);
     if segments.is_empty() {
+        return Ok(());
+    }
+
+    let content_hash = segments_fingerprint(&segments);
+    let unchanged = state_row
+        .as_ref()
+        .and_then(|s| s.content_hash.as_deref())
+        .is_some_and(|h| h == content_hash);
+
+    // Nothing new happened and we already have a narrative. Skip unless the day just
+    // ended and still needs its finalizing pass.
+    if unchanged
+        && state_row.as_ref().is_some_and(|s| s.has_narrative)
+        && !day_is_over
+    {
         return Ok(());
     }
 
     let (totals, top_apps, highlights) = aggregate(&segments);
     let rule_narrative = rule_based_narrative(&segments, &totals, &top_apps);
 
-    // Optional AI enrichment (never a hard dependency).
-    let (narrative, source) = match &state.screen_history_ai {
-        Some(cfg) => {
-            match ai_narrative(state, cfg, agent_id, day_start, now, &segments).await {
-                Ok(text) if !text.trim().is_empty() => (text, "ai"),
-                Ok(_) => (rule_narrative, "rule"),
+    // Optional AI enrichment (never a hard dependency). Rate-limited per agent-day:
+    // re-narrating an in-progress day on every tick multiplied the cost of a single
+    // day by the number of ticks in it. A finished day always gets one last call so
+    // its narrative covers the whole day rather than whenever the last tick landed.
+    let last_ai = state_row.as_ref().and_then(|s| s.ai_generated_at);
+    let ai_due = match last_ai {
+        None => true,
+        Some(at) => day_is_over || now - at >= AI_MIN_INTERVAL,
+    };
+    let want_ai = state.screen_history_ai.is_some() && ai_due && (!unchanged || day_is_over);
+
+    let (narrative, source, ai_refreshed) = match (&state.screen_history_ai, want_ai) {
+        (Some(cfg), true) => {
+            match ai_narrative(state, cfg, agent_id, day_start, upper, &segments, tz).await {
+                Ok(text) if !text.trim().is_empty() => (text, "ai", true),
+                Ok(_) => (rule_narrative, "rule", false),
                 Err(e) => {
                     warn!(%agent_id, "AI narrative failed, using rule-based: {e}");
-                    (rule_narrative, "rule")
+                    (rule_narrative, "rule", false)
                 }
             }
         }
-        None => (rule_narrative, "rule"),
+        // AI not configured, not due, or nothing changed: the rule-based narrative is
+        // regenerated cheaply so segments and totals stay live either way.
+        _ => (rule_narrative, "rule", false),
     };
 
     db::replace_activity_segments(&state.db, agent_id, day_start, day_end, &segments).await?;
     db::upsert_day_summary(
         &state.db,
-        agent_id,
-        day_start.date_naive(),
-        &narrative,
-        &totals,
-        &top_apps,
-        &highlights,
-        source,
+        db::DaySummaryWrite {
+            agent_id,
+            // The agent's local calendar date — the same key the read path derives
+            // from its own timezone, so writes and reads agree.
+            day: local_day,
+            narrative: &narrative,
+            totals: &totals,
+            top_apps: &top_apps,
+            highlights: &highlights,
+            source,
+            content_hash: &content_hash,
+            ai_refreshed,
+            finalized: day_is_over,
+        },
     )
     .await?;
     Ok(())
+}
+
+/// Stable fingerprint of a day's segments.
+///
+/// Two runs that would produce the same summary must produce the same hash, so the
+/// worker can skip the expensive path. Covers everything the summary is derived from
+/// — boundaries, category, and app — so a segment merely growing at the end (the
+/// common case as a day progresses) correctly reads as *changed*.
+fn segments_fingerprint(segs: &[SegmentInput]) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash as _, Hasher as _};
+
+    let mut h = DefaultHasher::new();
+    segs.len().hash(&mut h);
+    for s in segs {
+        s.start_ts.timestamp().hash(&mut h);
+        s.end_ts.timestamp().hash(&mut h);
+        s.category.hash(&mut h);
+        s.app.hash(&mut h);
+    }
+    format!("{:016x}", h.finish())
 }
 
 /// Coarse category + a 0..1 distraction score for an app/title pair.
@@ -324,14 +482,17 @@ async fn ai_narrative(
     from: DateTime<Utc>,
     to: DateTime<Utc>,
     segs: &[SegmentInput],
+    tz: chrono_tz::Tz,
 ) -> anyhow::Result<String> {
-    // Build a compact text digest of the day's segments.
+    // Build a compact text digest of the day's segments. Times are rendered in the
+    // agent's local zone — a narrative that says "worked late into the evening" has
+    // to be reading the same clock the person was.
     let mut digest = String::new();
     for s in segs.iter().take(60) {
         digest.push_str(&format!(
             "- {}–{} [{}] {}\n",
-            s.start_ts.format("%H:%M"),
-            s.end_ts.format("%H:%M"),
+            s.start_ts.with_timezone(&tz).format("%H:%M"),
+            s.end_ts.with_timezone(&tz).format("%H:%M"),
             s.category,
             s.summary.as_deref().unwrap_or(""),
         ));
@@ -400,5 +561,89 @@ fn truncate(s: &str, max: usize) -> String {
         let mut out: String = s.chars().take(max).collect();
         out.push('…');
         out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seg(start: i64, end: i64, category: &str, app: &str) -> SegmentInput {
+        SegmentInput {
+            start_ts: DateTime::from_timestamp(start, 0).unwrap(),
+            end_ts: DateTime::from_timestamp(end, 0).unwrap(),
+            category: category.into(),
+            app: Some(app.into()),
+            title: Some("t".into()),
+            summary: None,
+            distraction_score: 0.1,
+            source: "rule".into(),
+        }
+    }
+
+    #[test]
+    fn identical_segments_hash_identically() {
+        let a = vec![seg(0, 60, "dev", "code.exe"), seg(60, 120, "comms", "slack.exe")];
+        let b = vec![seg(0, 60, "dev", "code.exe"), seg(60, 120, "comms", "slack.exe")];
+        assert_eq!(segments_fingerprint(&a), segments_fingerprint(&b));
+    }
+
+    #[test]
+    fn a_growing_final_segment_changes_the_hash() {
+        // The common case as a day progresses: the last segment extends. If this
+        // read as "unchanged" the summary would freeze at the first tick of the day.
+        let before = vec![seg(0, 60, "dev", "code.exe")];
+        let after = vec![seg(0, 300, "dev", "code.exe")];
+        assert_ne!(segments_fingerprint(&before), segments_fingerprint(&after));
+    }
+
+    #[test]
+    fn a_new_segment_changes_the_hash() {
+        let before = vec![seg(0, 60, "dev", "code.exe")];
+        let after = vec![seg(0, 60, "dev", "code.exe"), seg(60, 120, "media", "vlc.exe")];
+        assert_ne!(segments_fingerprint(&before), segments_fingerprint(&after));
+    }
+
+    #[test]
+    fn switching_app_or_category_changes_the_hash() {
+        let base = vec![seg(0, 60, "dev", "code.exe")];
+        assert_ne!(
+            segments_fingerprint(&base),
+            segments_fingerprint(&[seg(0, 60, "dev", "idea.exe")])
+        );
+        assert_ne!(
+            segments_fingerprint(&base),
+            segments_fingerprint(&[seg(0, 60, "media", "code.exe")])
+        );
+    }
+
+    #[test]
+    fn fields_not_feeding_the_summary_do_not_churn_the_hash() {
+        // `summary` is derived from app/title and `source` is bookkeeping; letting
+        // them into the fingerprint would trigger pointless AI re-runs.
+        let mut a = seg(0, 60, "dev", "code.exe");
+        let mut b = seg(0, 60, "dev", "code.exe");
+        a.summary = Some("code.exe — main.rs".into());
+        b.summary = None;
+        a.source = "ai".into();
+        b.source = "rule".into();
+        assert_eq!(segments_fingerprint(&[a]), segments_fingerprint(&[b]));
+    }
+
+    #[test]
+    fn empty_and_nonempty_differ() {
+        assert_ne!(
+            segments_fingerprint(&[]),
+            segments_fingerprint(&[seg(0, 60, "dev", "code.exe")])
+        );
+    }
+
+    #[test]
+    fn local_midnight_matches_the_api_day_boundary() {
+        // Worker and read path must agree or the worker writes rows the API can't find.
+        let tz = chrono_tz::Australia::Perth;
+        let d = chrono::NaiveDate::from_ymd_opt(2026, 8, 8).unwrap();
+        let start = local_midnight_utc(d, tz).unwrap();
+        assert_eq!(start.to_rfc3339(), "2026-08-07T16:00:00+00:00");
     }
 }

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -154,6 +154,48 @@ pub struct AppState {
     /// Base64url VAPID public key for Web Push, exposed to the frontend for
     /// `PushManager.subscribe`. `None` when Web Push is not configured.
     pub vapid_public_key: Option<String>,
+
+    /// Last time each (viewer, agent, action) triple was written to the audit log,
+    /// so replaying a timeline records *that someone watched* without inserting a
+    /// row per keyframe. See [`Self::should_audit_recall_access`].
+    pub recall_audit_seen: Mutex<HashMap<(Uuid, Uuid, &'static str), Instant>>,
+}
+
+/// How long one audited Recall view "covers". A viewer scrubbing continuously logs
+/// one row per window rather than one per frame fetched.
+const RECALL_AUDIT_WINDOW: Duration = Duration::from_secs(10 * 60);
+/// Cap on tracked triples, so the throttle map can't grow without bound on a large
+/// fleet. Exceeding it prunes expired entries, then (worst case) clears.
+const RECALL_AUDIT_MAX_TRACKED: usize = 4_096;
+
+/// Key identifying one viewer's access of one agent's Recall data for one action.
+type RecallAuditKey = (Uuid, Uuid, &'static str);
+
+/// Decide whether this access should be audited, updating `seen` in place.
+///
+/// Split out from [`AppState::should_audit_recall_access`] so the throttle can be
+/// tested without standing up a database pool. `now` is injected for the same reason.
+fn recall_audit_decision(
+    seen: &mut HashMap<RecallAuditKey, Instant>,
+    key: RecallAuditKey,
+    now: Instant,
+) -> bool {
+    if seen.len() >= RECALL_AUDIT_MAX_TRACKED {
+        seen.retain(|_, at| now.duration_since(*at) < RECALL_AUDIT_WINDOW);
+        if seen.len() >= RECALL_AUDIT_MAX_TRACKED {
+            // Everything is live; drop the table rather than grow unbounded. Costs a
+            // burst of duplicate audit rows, never a missing one.
+            seen.clear();
+        }
+    }
+
+    match seen.get(&key) {
+        Some(at) if now.duration_since(*at) < RECALL_AUDIT_WINDOW => false,
+        _ => {
+            seen.insert(key, now);
+            true
+        }
+    }
 }
 
 /// Cached JPEG with a monotonic `seq` for MJPEG change detection.
@@ -246,6 +288,7 @@ impl AppState {
             screen_history_dir,
             screen_history_ai,
             vapid_public_key,
+            recall_audit_seen: Mutex::new(HashMap::new()),
         }
     }
 
@@ -402,6 +445,47 @@ impl AppState {
         tx.is_some_and(|tx| tx.send(frame).is_ok())
     }
 
+    /// Whether this Recall access should produce an audit row.
+    ///
+    /// Watching someone's screen history is the most privacy-sensitive thing this
+    /// product does, so it has to be on the record — but replaying an hour of
+    /// timeline fetches hundreds of keyframe blobs, and a row per blob would bury
+    /// the signal and hammer the DB. This collapses a continuous viewing session
+    /// into one audit row per [`RECALL_AUDIT_WINDOW`], entirely in memory.
+    ///
+    /// Returns `true` the first time a (viewer, agent, action) triple is seen and
+    /// then at most once per window. Deliberately fail-open on restart: a fresh
+    /// process re-logs, which over-records rather than under-records.
+    pub fn should_audit_recall_access(
+        &self,
+        user_id: Uuid,
+        agent_id: Uuid,
+        action: &'static str,
+    ) -> bool {
+        let mut seen = self.recall_audit_seen.lock();
+        recall_audit_decision(&mut seen, (user_id, agent_id, action), Instant::now())
+    }
+
+    /// Timezone to bucket an agent's Recall days in.
+    ///
+    /// Prefers the agent's self-reported IANA zone (`agent_info.timezone`), falling
+    /// back to the deployment's configured [`Self::scheduler_tz`] for agents too old
+    /// to report one, and finally to UTC. A "day summary" is meaningless without
+    /// this: bucketing by UTC gives a UTC+8 user a day that runs 8am–8am.
+    pub async fn agent_timezone(&self, agent_id: Uuid) -> chrono_tz::Tz {
+        match crate::db::agent_timezone(&self.db, agent_id).await {
+            Ok(Some(name)) => name.trim().parse::<chrono_tz::Tz>().unwrap_or_else(|_| {
+                tracing::debug!(%agent_id, tz = %name, "unrecognized agent timezone; using default");
+                self.scheduler_tz
+            }),
+            Ok(None) => self.scheduler_tz,
+            Err(e) => {
+                tracing::warn!(%agent_id, error = %e, "agent timezone lookup failed; using default");
+                self.scheduler_tz
+            }
+        }
+    }
+
     /// Forward a control payload to a connected agent (same wire format as viewer controls).
     pub fn try_send_agent_command_json(&self, agent_id: Uuid, cmd: &serde_json::Value) -> bool {
         let Ok(s) = serde_json::to_string(cmd) else {
@@ -439,5 +523,107 @@ impl AppState {
     pub fn route_terminal_output(&self, session_id: Uuid, frame: String) -> bool {
         let tx = self.terminal_sessions.lock().get(&session_id).cloned();
         tx.is_some_and(|tx| tx.try_send(frame).is_ok())
+    }
+}
+
+#[cfg(test)]
+mod recall_audit_tests {
+    use super::*;
+
+    const ACTION: &str = "recall_replay";
+
+    fn key() -> RecallAuditKey {
+        (Uuid::nil(), Uuid::nil(), ACTION)
+    }
+
+    #[test]
+    fn first_access_is_audited() {
+        let mut seen = HashMap::new();
+        assert!(recall_audit_decision(&mut seen, key(), Instant::now()));
+    }
+
+    #[test]
+    fn repeat_access_within_window_is_throttled() {
+        let mut seen = HashMap::new();
+        let t0 = Instant::now();
+        assert!(recall_audit_decision(&mut seen, key(), t0));
+        // A replay fetches hundreds of blobs; none of them should add a row.
+        for i in 1..500 {
+            let t = t0 + Duration::from_millis(i * 100);
+            assert!(
+                !recall_audit_decision(&mut seen, key(), t),
+                "blob fetch at +{i}00ms should not have been audited"
+            );
+        }
+    }
+
+    #[test]
+    fn access_after_window_is_audited_again() {
+        let mut seen = HashMap::new();
+        let t0 = Instant::now();
+        assert!(recall_audit_decision(&mut seen, key(), t0));
+        assert!(!recall_audit_decision(
+            &mut seen,
+            key(),
+            t0 + RECALL_AUDIT_WINDOW - Duration::from_secs(1)
+        ));
+        assert!(recall_audit_decision(
+            &mut seen,
+            key(),
+            t0 + RECALL_AUDIT_WINDOW + Duration::from_secs(1)
+        ));
+    }
+
+    #[test]
+    fn different_viewers_agents_and_actions_are_tracked_separately() {
+        let mut seen = HashMap::new();
+        let t = Instant::now();
+        let (viewer_a, viewer_b) = (Uuid::from_u128(1), Uuid::from_u128(2));
+        let (agent_a, agent_b) = (Uuid::from_u128(10), Uuid::from_u128(11));
+
+        assert!(recall_audit_decision(&mut seen, (viewer_a, agent_a, ACTION), t));
+        // A second operator watching the same agent must produce its own row.
+        assert!(recall_audit_decision(&mut seen, (viewer_b, agent_a, ACTION), t));
+        // Same operator, different agent: separate row.
+        assert!(recall_audit_decision(&mut seen, (viewer_a, agent_b, ACTION), t));
+        // Same operator+agent, different action: separate row.
+        assert!(recall_audit_decision(
+            &mut seen,
+            (viewer_a, agent_a, "recall_day_view"),
+            t
+        ));
+        // ...and each is now throttled independently.
+        assert!(!recall_audit_decision(&mut seen, (viewer_a, agent_a, ACTION), t));
+    }
+
+    #[test]
+    fn tracking_map_stays_bounded() {
+        let mut seen = HashMap::new();
+        let t0 = Instant::now();
+        // Far more distinct triples than the cap, all live.
+        for i in 0..(RECALL_AUDIT_MAX_TRACKED as u128 * 2) {
+            recall_audit_decision(&mut seen, (Uuid::from_u128(i), Uuid::nil(), ACTION), t0);
+        }
+        assert!(
+            seen.len() <= RECALL_AUDIT_MAX_TRACKED,
+            "throttle map grew past its cap: {}",
+            seen.len()
+        );
+    }
+
+    #[test]
+    fn expired_entries_are_pruned_before_clearing() {
+        let mut seen = HashMap::new();
+        let t0 = Instant::now();
+        for i in 0..RECALL_AUDIT_MAX_TRACKED as u128 {
+            recall_audit_decision(&mut seen, (Uuid::from_u128(i), Uuid::nil(), ACTION), t0);
+        }
+        // Well past the window: the next call should prune rather than clear, and the
+        // pruned map must still admit (and remember) the new access.
+        let later = t0 + RECALL_AUDIT_WINDOW + Duration::from_secs(1);
+        let fresh = (Uuid::from_u128(9_999_999), Uuid::nil(), ACTION);
+        assert!(recall_audit_decision(&mut seen, fresh, later));
+        assert!(!recall_audit_decision(&mut seen, fresh, later));
+        assert_eq!(seen.len(), 1, "expired entries should have been pruned");
     }
 }

--- a/server/src/ws_agent.rs
+++ b/server/src/ws_agent.rs
@@ -39,6 +39,10 @@ pub const MAX_AGENT_NAME_CHARS: usize = 128;
 /// ~3 MiB raw chunk → ~4.1 MiB base64 + JSON overhead (see agent `REMOTE_FILE_CHUNK_BYTES`).
 const MAX_AGENT_TEXT_BYTES: usize = 8 * 1024 * 1024;
 const MAX_AGENT_BINARY_BYTES: usize = 8 * 1024 * 1024; // JPEG frames
+/// Magic prefix marking a binary frame as a Recall keyframe (header JSON + raw JPEG),
+/// alongside `AUD\0` (audio) and bare JPEG (MJPEG) on the same socket.
+/// Keep in sync with `HISTORY_FRAME_MAGIC` in `agent/src/agent_loop.rs`.
+const HISTORY_FRAME_MAGIC: &[u8; 4] = b"HST\0";
 
 const MAX_KEYS_TEXT_CHARS: usize = 4_000;
 const MAX_URL_STR_BYTES: usize = 4_096;
@@ -227,6 +231,21 @@ async fn run(mut ws: WebSocket, name: String, state: Arc<AppState>) {
         }
     }
 
+    // Push Recall capture settings before the first keyframe of this session, so a
+    // cadence change or a kill switch set while this agent was offline applies now.
+    if let Ok(settings) = db::effective_recall_settings(&state.db, agent_id).await {
+        if !settings.is_null() {
+            let sync = serde_json::json!({
+                "type": "set_recall_settings",
+                "settings": settings,
+            })
+            .to_string();
+            if let Err(e) = ws.send(Message::Text(sync)).await {
+                warn!("Failed to push Recall capture settings to {name}: {e}");
+            }
+        }
+    }
+
     loop {
         tokio::select! {
             msg = ws.recv() => {
@@ -245,6 +264,11 @@ async fn run(mut ws: WebSocket, name: String, state: Arc<AppState>) {
                         if frame.len() >= 4 && &frame[..4] == b"AUD\0" {
                             // Audio PCM frame — fan-out to live audio viewers.
                             state.route_audio_frame(agent_id, frame);
+                        } else if frame.len() >= 4 && &frame[..4] == HISTORY_FRAME_MAGIC {
+                            // Recall keyframe — persist to the blob store + index.
+                            // Handled here (not fanned out) so the payload never
+                            // reaches dashboard viewers.
+                            ingest_history_frame_binary(agent_id, &frame, &state).await;
                         } else {
                             // JPEG screenshot frame — cache for MJPEG viewers.
                             state.store_frame(agent_id, frame);
@@ -411,6 +435,36 @@ pub async fn push_app_block_rules_to_agent(state: &Arc<AppState>, agent_id: uuid
     .to_string();
     if let Some(tx) = state.agent_cmds.lock().get(&agent_id) {
         let _ = tx.try_send(AgentControl::Text(payload));
+    }
+}
+
+/// Push effective Recall capture settings to one agent.
+///
+/// Settings are per-agent (global row + optional override), so unlike a fleet-wide
+/// policy this must be resolved and sent individually. Agents cache the result, so
+/// this is what makes a change take effect now rather than at the next reconnect.
+pub async fn push_recall_settings_to_agent(state: &Arc<AppState>, agent_id: uuid::Uuid) {
+    let Ok(settings) = db::effective_recall_settings(&state.db, agent_id).await else {
+        return;
+    };
+    if settings.is_null() {
+        return; // No global row yet; leave the agent on its built-in defaults.
+    }
+    let payload = serde_json::json!({
+        "type": "set_recall_settings",
+        "settings": settings,
+    })
+    .to_string();
+    if let Some(tx) = state.agent_cmds.lock().get(&agent_id) {
+        let _ = tx.try_send(AgentControl::Text(payload));
+    }
+}
+
+/// Push capture settings to every connected agent (after a global settings change).
+pub async fn push_recall_settings_to_all_connected(state: &Arc<AppState>) {
+    let ids: Vec<uuid::Uuid> = state.agents.lock().keys().copied().collect();
+    for id in ids {
+        push_recall_settings_to_agent(state, id).await;
     }
 }
 
@@ -740,9 +794,126 @@ async fn dispatch_val(
 const MAX_HISTORY_JPEG_BYTES: usize = 2 * 1024 * 1024;
 const MAX_OCR_TEXT_CHARS: usize = 20_000;
 
-/// Persist a `history_frame`: decode the base64 JPEG, write it to the blob store
-/// (`<dir>/<agent>/<YYYYMMDD>/<uuid>.jpg`), then insert the index row.
+/// Tell the agent a spooled keyframe is durably stored (or permanently unacceptable),
+/// so it can delete it from its on-disk spool.
+///
+/// `rejected` frames are ones no retry will fix — oversized, bad base64, unwritable
+/// blob. The agent drops those too: retrying forever would wedge its queue behind a
+/// frame that can never land. Transient failures (DB down) are deliberately *not*
+/// acked, so the agent re-sends them on its next session.
+fn ack_history_frame(
+    agent_id: Uuid,
+    val: &serde_json::Value,
+    state: &Arc<AppState>,
+    rejected: Option<&str>,
+) {
+    let Some(uid) = val["uid"].as_str().filter(|s| !s.is_empty()) else {
+        return; // Pre-spool agent; nothing to ack.
+    };
+    let mut ack = serde_json::json!({ "type": "history_frame_ack", "uid": uid });
+    if let Some(reason) = rejected {
+        ack["rejected"] = serde_json::Value::Bool(true);
+        ack["reason"] = serde_json::Value::String(reason.to_string());
+    }
+    state.try_send_agent_command_json(agent_id, &ack);
+}
+
+/// Persist a legacy JSON `history_frame` (base64 JPEG).
+///
+/// Superseded by the binary `HST\0` frame, which avoids base64's ~33% inflation on a
+/// socket shared with live telemetry. Kept so an agent that hasn't been updated yet
+/// keeps recording rather than silently losing its history.
 async fn ingest_history_frame(agent_id: Uuid, val: &serde_json::Value, state: &Arc<AppState>) {
+    let b64 = val["jpeg_b64"].as_str().unwrap_or("");
+    if b64.is_empty() {
+        warn!("Dropping history_frame from {agent_id}: empty jpeg_b64");
+        ack_history_frame(agent_id, val, state, Some("empty jpeg"));
+        return;
+    }
+    let jpeg = match base64::engine::general_purpose::STANDARD.decode(b64) {
+        Ok(bytes) if bytes.len() <= MAX_HISTORY_JPEG_BYTES => bytes,
+        Ok(bytes) => {
+            warn!(
+                "Dropping history_frame from {agent_id}: jpeg too large ({} bytes)",
+                bytes.len()
+            );
+            ack_history_frame(agent_id, val, state, Some("jpeg too large"));
+            return;
+        }
+        Err(e) => {
+            warn!("Dropping history_frame from {agent_id}: bad base64 ({e})");
+            ack_history_frame(agent_id, val, state, Some("bad base64"));
+            return;
+        }
+    };
+
+    store_history_frame(agent_id, val, jpeg, state).await;
+}
+
+/// Decode a binary `HST\0` keyframe and persist it.
+///
+/// Layout: `HST\0` + u32 LE header length + header JSON + raw JPEG bytes. This is the
+/// path modern agents use; the JSON/base64 `history_frame` event above is kept so an
+/// agent that hasn't been updated yet still works.
+async fn ingest_history_frame_binary(agent_id: Uuid, frame: &[u8], state: &Arc<AppState>) {
+    let (val, jpeg) = match parse_history_frame_binary(frame) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!("Dropping binary history frame from {agent_id}: {e}");
+            return;
+        }
+    };
+    if jpeg.is_empty() {
+        warn!("Dropping binary history frame from {agent_id}: empty jpeg");
+        ack_history_frame(agent_id, &val, state, Some("empty jpeg"));
+        return;
+    }
+    if jpeg.len() > MAX_HISTORY_JPEG_BYTES {
+        warn!(
+            "Dropping binary history frame from {agent_id}: jpeg too large ({} bytes)",
+            jpeg.len()
+        );
+        ack_history_frame(agent_id, &val, state, Some("jpeg too large"));
+        return;
+    }
+    store_history_frame(agent_id, &val, jpeg, state).await;
+}
+
+/// Split a binary `HST\0` keyframe into its header JSON and JPEG bytes.
+///
+/// Pure so the wire format can be tested directly: a mismatch between this and the
+/// agent's encoder would silently drop every keyframe on the floor.
+fn parse_history_frame_binary(
+    frame: &[u8],
+) -> Result<(serde_json::Value, Vec<u8>), &'static str> {
+    const PREFIX: usize = 8; // magic + u32 header length
+    if frame.len() < PREFIX {
+        return Err("truncated header");
+    }
+    if &frame[..4] != HISTORY_FRAME_MAGIC {
+        return Err("bad magic");
+    }
+    let hlen = u32::from_le_bytes([frame[4], frame[5], frame[6], frame[7]]) as usize;
+    let hend = PREFIX
+        .checked_add(hlen)
+        .filter(|e| *e <= frame.len())
+        .ok_or("bad header length")?;
+    let val: serde_json::Value =
+        serde_json::from_slice(&frame[PREFIX..hend]).map_err(|_| "bad header JSON")?;
+    Ok((val, frame[hend..].to_vec()))
+}
+
+/// Write the JPEG to the blob store and insert its index row, then ack.
+///
+/// Shared by both wire formats so the durability semantics — at-least-once with
+/// `client_uid` dedup, ack only on success, no ack on transient failure — live in one
+/// place regardless of how the bytes arrived.
+async fn store_history_frame(
+    agent_id: Uuid,
+    val: &serde_json::Value,
+    jpeg: Vec<u8>,
+    state: &Arc<AppState>,
+) {
     // captured_at is RFC3339 UTC; fall back to now if malformed rather than dropping.
     let captured_at = val["captured_at"]
         .as_str()
@@ -760,25 +931,18 @@ async fn ingest_history_frame(agent_id: Uuid, val: &serde_json::Value, state: &A
         .and_then(|s| s.trim().parse::<u64>().ok())
         .unwrap_or(0) as i64;
 
-    let b64 = val["jpeg_b64"].as_str().unwrap_or("");
-    if b64.is_empty() {
-        warn!("Dropping history_frame from {agent_id}: empty jpeg_b64");
-        return;
-    }
-    let jpeg = match base64::engine::general_purpose::STANDARD.decode(b64) {
-        Ok(bytes) if bytes.len() <= MAX_HISTORY_JPEG_BYTES => bytes,
-        Ok(bytes) => {
-            warn!(
-                "Dropping history_frame from {agent_id}: jpeg too large ({} bytes)",
-                bytes.len()
-            );
-            return;
-        }
-        Err(e) => {
-            warn!("Dropping history_frame from {agent_id}: bad base64 ({e})");
-            return;
-        }
-    };
+    // Agent-generated spool id; absent for pre-spool agents (then ingest is
+    // fire-and-forget, exactly as before).
+    let client_uid = val["uid"]
+        .as_str()
+        .and_then(|s| Uuid::parse_str(s.trim()).ok());
+
+    // Per-word OCR geometry, when the agent produced any. Stored as-is; the shape is
+    // validated by the frontend rather than re-parsed here.
+    let ocr_words = val
+        .get("ocr_words")
+        .filter(|v| v.is_array())
+        .filter(|v| !v.as_array().is_some_and(std::vec::Vec::is_empty));
 
     let ocr_text = val["ocr_text"]
         .as_str()
@@ -803,16 +967,20 @@ async fn ingest_history_frame(agent_id: Uuid, val: &serde_json::Value, state: &A
     match write_res {
         Ok(Ok(())) => {}
         Ok(Err(e)) => {
+            // Disk full / permissions: retrying the same frame won't help, and the
+            // agent's spool is bounded, so let it move on rather than jam.
             error!("history_frame blob write failed for {agent_id}: {e}");
+            ack_history_frame(agent_id, val, state, Some("blob write failed"));
             return;
         }
         Err(e) => {
             error!("history_frame blob write task panicked for {agent_id}: {e}");
+            ack_history_frame(agent_id, val, state, Some("blob write panicked"));
             return;
         }
     }
 
-    if let Err(e) = db::insert_screen_frame(
+    match db::insert_screen_frame(
         &state.db,
         agent_id,
         captured_at,
@@ -822,11 +990,26 @@ async fn ingest_history_frame(agent_id: Uuid, val: &serde_json::Value, state: &A
         phash,
         &rel,
         ocr_text.as_deref(),
+        ocr_words,
+        client_uid,
     )
     .await
     {
-        error!("insert_screen_frame failed for {agent_id}: {e}");
-        // Orphaned blob: cheap to leave; retention's day-dir sweep reclaims it.
+        Ok(Some(_)) => ack_history_frame(agent_id, val, state, None),
+        Ok(None) => {
+            // Already stored — the agent re-sent after a lost ack. The blob we just
+            // wrote is a duplicate of the one the original row points at, so drop it
+            // rather than leave it orphaned until the day-dir sweep.
+            let dup = state.screen_history_dir.join(&rel);
+            let _ = tokio::fs::remove_file(dup).await;
+            ack_history_frame(agent_id, val, state, None);
+        }
+        Err(e) => {
+            // Transient (DB down / lock contention): do NOT ack, so the agent keeps
+            // the frame spooled and re-sends it later.
+            error!("insert_screen_frame failed for {agent_id}: {e}");
+            // Orphaned blob: cheap to leave; retention's day-dir sweep reclaims it.
+        }
     }
 }
 
@@ -850,4 +1033,119 @@ async fn dispatch_text(text: &str, agent_id: uuid::Uuid, name: &str, state: &Arc
     }
 
     dispatch_val(val, agent_id, name, state).await;
+}
+
+#[cfg(test)]
+mod history_frame_wire_tests {
+    use super::*;
+
+    /// Build a frame exactly the way `agent/src/agent_loop.rs::pump_history_spool`
+    /// does. If the two encoders drift apart, these tests fail rather than the fleet
+    /// silently losing its screen history.
+    fn encode(header: &serde_json::Value, jpeg: &[u8]) -> Vec<u8> {
+        let hb = serde_json::to_vec(header).unwrap();
+        let mut out = Vec::new();
+        out.extend_from_slice(HISTORY_FRAME_MAGIC);
+        out.extend_from_slice(&(hb.len() as u32).to_le_bytes());
+        out.extend_from_slice(&hb);
+        out.extend_from_slice(jpeg);
+        out
+    }
+
+    fn sample_header() -> serde_json::Value {
+        serde_json::json!({
+            "uid": "3f1a9c62-0000-4000-8000-000000000001",
+            "captured_at": "2026-08-08T01:23:45+00:00",
+            "monitor": 1,
+            "w": 1600,
+            "h": 900,
+            "phash": u64::MAX.to_string(),
+            "ocr_text": "hello world",
+        })
+    }
+
+    #[test]
+    fn round_trips_header_and_jpeg() {
+        let jpeg: Vec<u8> = (0..=255u8).cycle().take(5000).collect();
+        let frame = encode(&sample_header(), &jpeg);
+        let (val, out) = parse_history_frame_binary(&frame).unwrap();
+
+        assert_eq!(out, jpeg, "JPEG bytes must survive framing exactly");
+        assert_eq!(val["monitor"].as_i64(), Some(1));
+        assert_eq!(val["w"].as_i64(), Some(1600));
+        assert_eq!(val["ocr_text"].as_str(), Some("hello world"));
+        // The u64 aHash must survive as a string — a JSON number would lose bits.
+        assert_eq!(val["phash"].as_str(), Some(u64::MAX.to_string().as_str()));
+    }
+
+    #[test]
+    fn binary_framing_is_smaller_than_base64_json() {
+        // The whole point of the format: no ~33% inflation on a shared socket.
+        let jpeg: Vec<u8> = (0..=255u8).cycle().take(40_000).collect();
+        let binary = encode(&sample_header(), &jpeg).len();
+        let legacy = serde_json::json!({
+            "type": "history_frame",
+            "uid": sample_header()["uid"],
+            "captured_at": sample_header()["captured_at"],
+            "monitor": 1, "w": 1600, "h": 900,
+            "phash": u64::MAX.to_string(),
+            "jpeg_b64": base64::engine::general_purpose::STANDARD.encode(&jpeg),
+            "ocr_text": "hello world",
+        })
+        .to_string()
+        .len();
+        assert!(
+            binary < legacy,
+            "binary framing ({binary}B) should beat base64 JSON ({legacy}B)"
+        );
+        // Base64 is 4/3 of the payload, so the saving should be roughly a quarter.
+        assert!(legacy - binary > jpeg.len() / 4);
+    }
+
+    #[test]
+    fn empty_jpeg_parses_but_yields_no_bytes() {
+        // Parsing succeeds; the caller is what rejects and acks it.
+        let frame = encode(&sample_header(), &[]);
+        let (_, out) = parse_history_frame_binary(&frame).unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn rejects_wrong_magic() {
+        let mut frame = encode(&sample_header(), &[1, 2, 3]);
+        frame[..4].copy_from_slice(b"AUD\0");
+        assert_eq!(parse_history_frame_binary(&frame), Err("bad magic"));
+    }
+
+    #[test]
+    fn rejects_truncated_and_overlong_headers() {
+        assert_eq!(
+            parse_history_frame_binary(b"HST\0"),
+            Err("truncated header")
+        );
+        // Header length pointing past the end of the buffer must not panic.
+        let mut frame = encode(&sample_header(), &[1, 2, 3]);
+        frame[4..8].copy_from_slice(&u32::MAX.to_le_bytes());
+        assert_eq!(parse_history_frame_binary(&frame), Err("bad header length"));
+    }
+
+    #[test]
+    fn rejects_malformed_header_json() {
+        let mut out = Vec::new();
+        out.extend_from_slice(HISTORY_FRAME_MAGIC);
+        out.extend_from_slice(&5u32.to_le_bytes());
+        out.extend_from_slice(b"{not!");
+        out.extend_from_slice(&[0xFF, 0xD8]);
+        assert_eq!(parse_history_frame_binary(&out), Err("bad header JSON"));
+    }
+
+    #[test]
+    fn a_jpeg_starting_with_other_magics_is_not_confused() {
+        // Guard the dispatch convention: a Recall frame is identified by its own
+        // prefix, and arbitrary JPEG payload bytes inside it can't re-trigger it.
+        let jpeg = b"HST\0AUD\0 arbitrary payload".to_vec();
+        let frame = encode(&sample_header(), &jpeg);
+        let (_, out) = parse_history_frame_binary(&frame).unwrap();
+        assert_eq!(out, jpeg);
+    }
 }


### PR DESCRIPTION
The live screen was blank and uncontrollable at the lock screen (and before first sign-in) even though the host showed as connected. Capture and input were done only by the user-session companion, which is pinned to winsta0\default with the user's token: it cannot reach the secure Winlogon desktop, and pre-login there is no user token so the companion isn't running at all. Nothing ever attached to the input desktop.

Add a SYSTEM capture worker the Session 0 service launches into the console session (present from the sign-in screen onward) that re-attaches its capture and input threads to whichever desktop currently owns input (Default when signed in, Winlogon when locked).

- role.rs: Standalone / Companion / CaptureWorker roles.
- secure_desktop.rs: attach the calling thread to the live input desktop (OpenInputDesktop/SetThreadDesktop) and detect switches; add the Win32_System_StationsAndDesktops feature.
- capture_worker.rs: --capture-worker SYSTEM process; another AGENT_IPC client handling only capture + input, with a dedicated input thread