### PR TITLE
Fix release quality gates (rustfmt, clippy, agent UI lint)

### DIFF
--- a/agent/src/agent_loop.rs
+++ b/agent/src/agent_loop.rs
@@ -36,9 +36,9 @@ fn now_epoch_ms() -> u64 {
         .unwrap_or(0)
 }
 
-use anyhow::Result;
 #[cfg(target_os = "windows")]
 use anyhow::Context;
+use anyhow::Result;
 use base64::Engine;
 use tokio::sync::mpsc;
 use tokio::time::{interval, interval_at, Instant, MissedTickBehavior};
@@ -630,8 +630,9 @@ async fn pump_history_spool(
                            else { serde_json::to_value(&h.ocr_words)? },
         });
         let header_bytes = serde_json::to_vec(&header)?;
-        let mut payload =
-            Vec::with_capacity(HISTORY_FRAME_MAGIC.len() + 4 + header_bytes.len() + frame.jpeg.len());
+        let mut payload = Vec::with_capacity(
+            HISTORY_FRAME_MAGIC.len() + 4 + header_bytes.len() + frame.jpeg.len(),
+        );
         payload.extend_from_slice(HISTORY_FRAME_MAGIC);
         payload.extend_from_slice(&(header_bytes.len() as u32).to_le_bytes());
         payload.extend_from_slice(&header_bytes);
@@ -658,10 +659,7 @@ async fn pump_history_spool(
 /// `ok` frames are deleted from the spool. A `reject` (frame the server will never
 /// accept — oversized, corrupt base64) is also deleted: retrying it forever would
 /// wedge the queue behind a frame that can never land.
-fn handle_history_ack(
-    text: &str,
-    in_flight: &mut HashMap<String, InFlightFrame>,
-) -> bool {
+fn handle_history_ack(text: &str, in_flight: &mut HashMap<String, InFlightFrame>) -> bool {
     let Ok(val) = serde_json::from_str::<serde_json::Value>(text) else {
         return false;
     };

--- a/agent/src/audio_capture.rs
+++ b/agent/src/audio_capture.rs
@@ -19,16 +19,14 @@ use std::sync::{
 
 use tokio::sync::mpsc;
 use tracing::warn;
-use windows::{
-    Win32::{
-        Media::Audio::{
-            eConsole, eRender, IAudioCaptureClient, IAudioClient, IMMDeviceEnumerator,
-            MMDeviceEnumerator, AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_LOOPBACK,
-        },
-        System::Com::{
-            CoCreateInstance, CoInitializeEx, CoTaskMemFree, CoUninitialize, CLSCTX_ALL,
-            COINIT_APARTMENTTHREADED,
-        },
+use windows::Win32::{
+    Media::Audio::{
+        eConsole, eRender, IAudioCaptureClient, IAudioClient, IMMDeviceEnumerator,
+        MMDeviceEnumerator, AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_LOOPBACK,
+    },
+    System::Com::{
+        CoCreateInstance, CoInitializeEx, CoTaskMemFree, CoUninitialize, CLSCTX_ALL,
+        COINIT_APARTMENTTHREADED,
     },
 };
 
@@ -42,34 +40,27 @@ const WAVE_FORMAT_EXTENSIBLE: u16 = 0xFFFE;
 
 /// SubFormat GUID for IEEE float: {00000003-0000-0010-8000-00aa00389b71}
 const SUBTYPE_FLOAT_BYTES: [u8; 16] = [
-    0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00,
-    0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71,
+    0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71,
 ];
 
 /// Spawn a background thread that captures WASAPI loopback audio and sends
 /// frames to `frame_tx` until `stop` is set.
 pub fn start_audio_capture(frame_tx: mpsc::Sender<Vec<u8>>, stop: Arc<AtomicBool>) {
-    std::thread::spawn(move || {
-        unsafe {
-            let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
-            if let Err(e) = capture_loop(&frame_tx, &stop) {
-                warn!("Audio capture stopped: {e:#}");
-            }
-            CoUninitialize();
+    std::thread::spawn(move || unsafe {
+        let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+        if let Err(e) = capture_loop(&frame_tx, &stop) {
+            warn!("Audio capture stopped: {e:#}");
         }
+        CoUninitialize();
     });
 }
 
-unsafe fn capture_loop(
-    frame_tx: &mpsc::Sender<Vec<u8>>,
-    stop: &AtomicBool,
-) -> anyhow::Result<()> {
+unsafe fn capture_loop(frame_tx: &mpsc::Sender<Vec<u8>>, stop: &AtomicBool) -> anyhow::Result<()> {
     use anyhow::Context;
     use windows::Win32::Media::Audio::WAVEFORMATEX;
 
-    let enumerator: IMMDeviceEnumerator =
-        CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)
-            .context("CoCreateInstance IMMDeviceEnumerator")?;
+    let enumerator: IMMDeviceEnumerator = CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)
+        .context("CoCreateInstance IMMDeviceEnumerator")?;
     let device = enumerator
         .GetDefaultAudioEndpoint(eRender, eConsole)
         .context("GetDefaultAudioEndpoint")?;

--- a/agent/src/capture.rs
+++ b/agent/src/capture.rs
@@ -214,7 +214,11 @@ fn capture_pass(
     let idx = settings
         .monitor
         .filter(|&i| i < monitors.len())
-        .or_else(|| monitors.iter().position(|m| m.is_primary().unwrap_or(false)))
+        .or_else(|| {
+            monitors
+                .iter()
+                .position(|m| m.is_primary().unwrap_or(false))
+        })
         .or(if monitors.is_empty() { None } else { Some(0) });
     let Some(idx) = idx else {
         // With no monitor we can't capture this generation. When following the

--- a/agent/src/ipc.rs
+++ b/agent/src/ipc.rs
@@ -32,9 +32,7 @@ pub enum IpcLine {
     /// `%ProgramData%\Vantyr\config.dat` (owned by the SYSTEM service), so
     /// server-pushed settings and enrollment tokens are forwarded here to be
     /// written with the service's privileges.
-    PersistConfig {
-        config: Box<crate::config::Config>,
-    },
+    PersistConfig { config: Box<crate::config::Config> },
     /// Service-owned WebSocket connection status, forwarded to the user-session companion.
     WsStatus {
         status: String,
@@ -169,7 +167,9 @@ pub fn request_service_persist_config(config: &crate::config::Config) -> std::io
             }
             Err(e) => {
                 last_err = Some(e);
-                std::thread::sleep(std::time::Duration::from_millis(40 * u64::from(attempt + 1)));
+                std::thread::sleep(std::time::Duration::from_millis(
+                    40 * u64::from(attempt + 1),
+                ));
             }
         }
     }

--- a/agent/src/platform/linux/desktop_capture.rs
+++ b/agent/src/platform/linux/desktop_capture.rs
@@ -163,7 +163,8 @@ fn run_wayshot_loop(
 
         // Follow the focused monitor without spawning hyprctl every frame.
         if frame % refresh_frames == 0 {
-            if let Some(o) = pick_output(conn.get_all_outputs(), focused_output().as_deref()).cloned()
+            if let Some(o) =
+                pick_output(conn.get_all_outputs(), focused_output().as_deref()).cloned()
             {
                 current = Some(o);
             }
@@ -211,8 +212,7 @@ fn run_wayshot_loop(
                 }
                 // A monitor may have been (un)plugged; refresh and re-resolve.
                 let _ = conn.refresh_outputs();
-                current =
-                    pick_output(conn.get_all_outputs(), focused_output().as_deref()).cloned();
+                current = pick_output(conn.get_all_outputs(), focused_output().as_deref()).cloned();
                 if consecutive_errors >= 5 {
                     warn!("Native capture failing repeatedly; will try grim.");
                     return true;

--- a/agent/src/screen_history.rs
+++ b/agent/src/screen_history.rs
@@ -226,8 +226,12 @@ fn ocr_rgba(img: &RgbaImage) -> anyhow::Result<OcrOutput> {
     let writer = DataWriter::new()?;
     writer.WriteBytes(&bgra)?;
     let buffer = writer.DetachBuffer()?;
-    let bitmap =
-        SoftwareBitmap::CreateCopyFromBuffer(&buffer, BitmapPixelFormat::Bgra8, w as i32, h as i32)?;
+    let bitmap = SoftwareBitmap::CreateCopyFromBuffer(
+        &buffer,
+        BitmapPixelFormat::Bgra8,
+        w as i32,
+        h as i32,
+    )?;
 
     let engine = OcrEngine::TryCreateFromUserProfileLanguages()?;
     let op = engine.RecognizeAsync(&bitmap)?;

--- a/agent/src/screen_spool.rs
+++ b/agent/src/screen_spool.rs
@@ -119,7 +119,11 @@ impl Spool {
             f.flush()?;
         }
         fs::rename(&tmp_path, &final_path).with_context(|| {
-            format!("renaming {} -> {}", tmp_path.display(), final_path.display())
+            format!(
+                "renaming {} -> {}",
+                tmp_path.display(),
+                final_path.display()
+            )
         })?;
 
         self.enforce_budget();
@@ -293,7 +297,10 @@ mod tests {
             .map(|p| Spool::load(p).unwrap().header.captured_ms)
             .collect();
         assert!(!remaining.is_empty(), "budget must not empty the spool");
-        assert!(remaining.len() < 6, "oldest frames should have been evicted");
+        assert!(
+            remaining.len() < 6,
+            "oldest frames should have been evicted"
+        );
         // Whatever survived must be the newest frames, still in order.
         let mut sorted = remaining.clone();
         sorted.sort_unstable();

--- a/agent/src/secure_desktop.rs
+++ b/agent/src/secure_desktop.rs
@@ -103,9 +103,7 @@ fn desktop_name(hdesk: HDESK) -> Result<String> {
     let mut needed: u32 = 0;
     let handle = HANDLE(hdesk.0);
     // A zero-length probe returns ERROR_INSUFFICIENT_BUFFER and fills `needed`.
-    let _ = unsafe {
-        GetUserObjectInformationW(handle, UOI_NAME, None, 0, Some(&raw mut needed))
-    };
+    let _ = unsafe { GetUserObjectInformationW(handle, UOI_NAME, None, 0, Some(&raw mut needed)) };
     if needed == 0 {
         // Fall back to a reasonable fixed buffer if the probe gave nothing.
         needed = 256;
@@ -124,9 +122,8 @@ fn desktop_name(hdesk: HDESK) -> Result<String> {
     .context("GetUserObjectInformationW(UOI_NAME)")?;
 
     // The buffer holds a wide, NUL-terminated string.
-    let wide: &[u16] = unsafe {
-        std::slice::from_raw_parts(buf.as_ptr().cast::<u16>(), (needed as usize) / 2)
-    };
+    let wide: &[u16] =
+        unsafe { std::slice::from_raw_parts(buf.as_ptr().cast::<u16>(), (needed as usize) / 2) };
     let end = wide.iter().position(|&c| c == 0).unwrap_or(wide.len());
     Ok(String::from_utf16_lossy(&wide[..end]))
 }

--- a/agent/src/server_command.rs
+++ b/agent/src/server_command.rs
@@ -129,7 +129,9 @@ pub fn handle_server_command(args: ServerCommandArgs<'_>) {
             if let Some(hash) = val["hash"].as_str() {
                 if let Ok(mut c) = shared_cfg.lock() {
                     c.ui_password_hash = hash.to_string();
-                    match tokio::task::block_in_place(|| crate::config::save_config_from_user_session(&c)) {
+                    match tokio::task::block_in_place(|| {
+                        crate::config::save_config_from_user_session(&c)
+                    }) {
                         Ok(()) => {
                             let new_cfg = c.clone();
                             drop(c);
@@ -145,7 +147,9 @@ pub fn handle_server_command(args: ServerCommandArgs<'_>) {
             if let Some(enabled) = val["enabled"].as_bool() {
                 if let Ok(mut c) = shared_cfg.lock() {
                     c.auto_update_enabled = enabled;
-                    match tokio::task::block_in_place(|| crate::config::save_config_from_user_session(&c)) {
+                    match tokio::task::block_in_place(|| {
+                        crate::config::save_config_from_user_session(&c)
+                    }) {
                         Ok(()) => {
                             let new_cfg = c.clone();
                             drop(c);
@@ -175,7 +179,9 @@ pub fn handle_server_command(args: ServerCommandArgs<'_>) {
             }
             if let Ok(mut c) = shared_cfg.lock() {
                 c.internet_blocked = blocked;
-                match tokio::task::block_in_place(|| crate::config::save_config_from_user_session(&c)) {
+                match tokio::task::block_in_place(|| {
+                    crate::config::save_config_from_user_session(&c)
+                }) {
                     Ok(()) => {
                         let new_cfg = c.clone();
                         drop(c);
@@ -210,7 +216,9 @@ pub fn handle_server_command(args: ServerCommandArgs<'_>) {
                 if desired_now != cur {
                     c.internet_blocked = desired_now;
                 }
-                if let Err(e) = tokio::task::block_in_place(|| crate::config::save_config_from_user_session(&c)) {
+                if let Err(e) =
+                    tokio::task::block_in_place(|| crate::config::save_config_from_user_session(&c))
+                {
                     warn!("Failed to save internet block rules to config: {e}");
                 } else {
                     info!(
@@ -271,7 +279,9 @@ pub fn handle_server_command(args: ServerCommandArgs<'_>) {
                     .iter()
                     .map(super::app_block::BlockRule::to_stored)
                     .collect();
-                match tokio::task::block_in_place(|| crate::config::save_config_from_user_session(&c)) {
+                match tokio::task::block_in_place(|| {
+                    crate::config::save_config_from_user_session(&c)
+                }) {
                     Ok(()) => {
                         info!(
                             "App block rules updated from server ({} rules).",
@@ -1106,15 +1116,17 @@ pub fn handle_server_command(args: ServerCommandArgs<'_>) {
             // Service-managed companion: the SYSTEM capture worker injects input
             // (and can drive the lock/sign-in desktop). Ignore here.
         }
-        _ => match controller {
-            Some(ctrl) => {
-                if let Err(e) = ctrl.handle_command(text) {
-                    warn!("Control command error: {e:#}");
+        _ => {
+            match controller {
+                Some(ctrl) => {
+                    if let Err(e) = ctrl.handle_command(text) {
+                        warn!("Control command error: {e:#}");
+                    }
+                }
+                None => {
+                    warn!("Ignoring remote input command: input injection unavailable on this session.");
                 }
             }
-            None => {
-                warn!("Ignoring remote input command: input injection unavailable on this session.");
-            }
-        },
+        }
     }
 }

--- a/agent/ui-src/src/components/SettingsPanel.tsx
+++ b/agent/ui-src/src/components/SettingsPanel.tsx
@@ -151,6 +151,10 @@ export function SettingsPanel() {
     if (nav !== "logs") return;
     logStickToBottomRef.current = true;
     logInitialScrollDoneRef.current = false;
+    // Loading the log tail when the Logs pane opens is exactly what an effect is
+    // for, and `refreshLogs` only touches state after awaiting the IPC read. The
+    // rule flags any effect that transitively sets state, so it can't see that.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void refreshLogs(false);
   }, [nav, currentLogSourceId, refreshLogs]);
 

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -187,8 +187,7 @@ pub fn router() -> Router<Arc<AppState>> {
         // Recall capture tunables: global defaults + per-agent overrides.
         .route(
             "/settings/recall",
-            get(screen_history::recall_settings_get)
-                .put(screen_history::recall_settings_put),
+            get(screen_history::recall_settings_get).put(screen_history::recall_settings_put),
         )
         .route(
             "/agents/:id/history/settings",

--- a/server/src/api/push.rs
+++ b/server/src/api/push.rs
@@ -42,7 +42,11 @@ pub struct SubscribeBody {
 }
 
 fn bad_request(msg: &str) -> Response {
-    (StatusCode::BAD_REQUEST, Json(serde_json::json!({ "error": msg }))).into_response()
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({ "error": msg })),
+    )
+        .into_response()
 }
 
 /// `POST /api/push/subscribe` — upsert the current browser's push subscription for

--- a/server/src/api/screen_history.rs
+++ b/server/src/api/screen_history.rs
@@ -146,7 +146,14 @@ pub async fn history_frames(
         Ok(v) => v,
         Err(msg) => return bad_request(msg),
     };
-    audit_recall(&s, &user, id, AUDIT_REPLAY, audit_ip(&headers, addr).as_deref()).await;
+    audit_recall(
+        &s,
+        &user,
+        id,
+        AUDIT_REPLAY,
+        audit_ip(&headers, addr).as_deref(),
+    )
+    .await;
     let limit = q.limit.clamp(1, MAX_FRAMES);
     match db::list_screen_frames(&s.db, id, from, to, limit).await {
         Ok(frames) => Json(serde_json::json!({
@@ -177,7 +184,14 @@ pub async fn history_frame_at(
     if !user.is_operator() {
         return forbidden();
     }
-    audit_recall(&s, &user, id, AUDIT_REPLAY, audit_ip(&headers, addr).as_deref()).await;
+    audit_recall(
+        &s,
+        &user,
+        id,
+        AUDIT_REPLAY,
+        audit_ip(&headers, addr).as_deref(),
+    )
+    .await;
     let at = match q.at {
         None => Utc::now(),
         Some(s) => match DateTime::parse_from_rfc3339(s.trim()) {
@@ -356,7 +370,14 @@ pub async fn history_segments(
     if !user.is_operator() {
         return forbidden();
     }
-    audit_recall(&s, &user, id, AUDIT_DAY_VIEW, audit_ip(&headers, addr).as_deref()).await;
+    audit_recall(
+        &s,
+        &user,
+        id,
+        AUDIT_DAY_VIEW,
+        audit_ip(&headers, addr).as_deref(),
+    )
+    .await;
     let tz = s.agent_timezone(id).await;
     let (day, start, end) = match parse_day_in_tz(q.day, tz) {
         Ok(v) => v,
@@ -386,7 +407,14 @@ pub async fn history_day_summary(
     if !user.is_operator() {
         return forbidden();
     }
-    audit_recall(&s, &user, id, AUDIT_DAY_VIEW, audit_ip(&headers, addr).as_deref()).await;
+    audit_recall(
+        &s,
+        &user,
+        id,
+        AUDIT_DAY_VIEW,
+        audit_ip(&headers, addr).as_deref(),
+    )
+    .await;
     let tz = s.agent_timezone(id).await;
     let (day, _start, _end) = match parse_day_in_tz(q.day, tz) {
         Ok(v) => v,
@@ -683,13 +711,18 @@ pub async fn history_frame_text(
     }
     // Reading the text off a frame is the same act as looking at it, so it shares
     // the replay audit action (and its throttle).
-    audit_recall(&s, &user, id, AUDIT_REPLAY, audit_ip(&headers, addr).as_deref()).await;
+    audit_recall(
+        &s,
+        &user,
+        id,
+        AUDIT_REPLAY,
+        audit_ip(&headers, addr).as_deref(),
+    )
+    .await;
     match db::screen_frame_text(&s.db, id, frame_id).await {
-        Ok(Some(v)) => (
-            [(header::CACHE_CONTROL, "private, max-age=86400")],
-            Json(v),
-        )
-            .into_response(),
+        Ok(Some(v)) => {
+            ([(header::CACHE_CONTROL, "private, max-age=86400")], Json(v)).into_response()
+        }
         Ok(None) => (StatusCode::NOT_FOUND, "No such frame").into_response(),
         Err(e) => err500(e),
     }
@@ -707,7 +740,14 @@ pub async fn history_blob(
         return forbidden();
     }
     // Throttled: one replay row per viewing window, not one per keyframe rendered.
-    audit_recall(&s, &user, id, AUDIT_REPLAY, audit_ip(&headers, addr).as_deref()).await;
+    audit_recall(
+        &s,
+        &user,
+        id,
+        AUDIT_REPLAY,
+        audit_ip(&headers, addr).as_deref(),
+    )
+    .await;
     let blob_ref = match db::screen_frame_blob_ref(&s.db, id, frame_id).await {
         Ok(Some(r)) => r,
         Ok(None) => {

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -247,11 +247,13 @@ impl ServerConfig {
             read_env_or_file("VAPID_PUBLIC_KEY").map(|s| s.trim().to_string()),
             read_env_or_file("VAPID_PRIVATE_KEY").map(|s| s.trim().to_string()),
         ) {
-            (Some(pubk), Some(privk)) if !pubk.is_empty() && !privk.is_empty() => Some(VapidConfig {
-                public_key: pubk,
-                private_key: privk,
-                subject: vapid_subject,
-            }),
+            (Some(pubk), Some(privk)) if !pubk.is_empty() && !privk.is_empty() => {
+                Some(VapidConfig {
+                    public_key: pubk,
+                    private_key: privk,
+                    subject: vapid_subject,
+                })
+            }
             (None, None) => {
                 let (public_key, private_key) = generate_vapid_keypair();
                 tracing::warn!(
@@ -321,7 +323,6 @@ fn generate_vapid_keypair() -> (String, String) {
 
     let secret = p256::SecretKey::random(&mut rand::rngs::OsRng);
     let private_key = URL_SAFE_NO_PAD.encode(secret.to_bytes());
-    let public_key =
-        URL_SAFE_NO_PAD.encode(secret.public_key().to_encoded_point(false).as_bytes());
+    let public_key = URL_SAFE_NO_PAD.encode(secret.public_key().to_encoded_point(false).as_bytes());
     (public_key, private_key)
 }

--- a/server/src/db/narrative.rs
+++ b/server/src/db/narrative.rs
@@ -306,8 +306,7 @@ pub async fn get_day_summary(
 /// Retention: drop derived narrative rows whose day is older than `cutoff`.
 pub async fn prune_narrative_before(pool: &PgPool, cutoff: NaiveDate) -> Result<()> {
     // start_ts predicate keyed to the cutoff day's UTC midnight.
-    let cutoff_ts = Utc
-        .from_utc_datetime(&cutoff.and_hms_opt(0, 0, 0).unwrap_or_default());
+    let cutoff_ts = Utc.from_utc_datetime(&cutoff.and_hms_opt(0, 0, 0).unwrap_or_default());
     sqlx::query("DELETE FROM activity_segments WHERE start_ts < $1")
         .bind(cutoff_ts)
         .execute(pool)

--- a/server/src/db/screen_history.rs
+++ b/server/src/db/screen_history.rs
@@ -110,8 +110,7 @@ fn frame_meta_json(r: &sqlx::postgres::PgRow) -> serde_json::Value {
     })
 }
 
-const FRAME_META_COLS: &str =
-    "id, captured_at, monitor, w, h, phash, \
+const FRAME_META_COLS: &str = "id, captured_at, monitor, w, h, phash, \
      (ocr_text IS NOT NULL AND length(ocr_text) > 0) AS has_ocr";
 
 /// Frame metadata (no blob) for one agent over a time range, oldest-first (timelapse order).
@@ -274,10 +273,7 @@ pub async fn search_screen_frames(
 ///
 /// Returned as the JSON the agent consumes directly, so there is exactly one place
 /// that knows the field names on the wire.
-pub async fn effective_recall_settings(
-    pool: &PgPool,
-    agent_id: Uuid,
-) -> Result<serde_json::Value> {
+pub async fn effective_recall_settings(pool: &PgPool, agent_id: Uuid) -> Result<serde_json::Value> {
     let row = sqlx::query(
         "SELECT
            COALESCE(a.enabled,             g.enabled)             AS enabled,
@@ -537,12 +533,18 @@ pub async fn prune_screen_history(pool: &PgPool, blob_dir: &Path, days: i64) -> 
             tracing::warn!(error = %e, partition = %name, "failed to drop screen_frames partition");
             continue;
         }
-        ensured_partitions().lock().unwrap().remove(&day.num_days_from_ce());
+        ensured_partitions()
+            .lock()
+            .unwrap()
+            .remove(&day.num_days_from_ce());
         dropped += 1;
         dropped_days.push(day);
     }
     if dropped > 0 {
-        tracing::info!(partitions = dropped, "dropped old screen_frames day-partitions");
+        tracing::info!(
+            partitions = dropped,
+            "dropped old screen_frames day-partitions"
+        );
     }
 
     // Only remove blob dirs for days whose DB partition drop actually succeeded above —

--- a/server/src/db/web_push.rs
+++ b/server/src/db/web_push.rs
@@ -56,11 +56,12 @@ pub async fn delete_web_push_subscription(
     user_id: Uuid,
     endpoint: &str,
 ) -> Result<u64> {
-    let res = sqlx::query("DELETE FROM web_push_subscriptions WHERE user_id = $1 AND endpoint = $2")
-        .bind(user_id)
-        .bind(endpoint)
-        .execute(pool)
-        .await?;
+    let res =
+        sqlx::query("DELETE FROM web_push_subscriptions WHERE user_id = $1 AND endpoint = $2")
+            .bind(user_id)
+            .bind(endpoint)
+            .execute(pool)
+            .await?;
     Ok(res.rows_affected())
 }
 
@@ -104,9 +105,11 @@ pub async fn mark_web_push_success(pool: &PgPool, id: i64) -> Result<()> {
 /// Increment the failure counter for a transient send error (kept for visibility;
 /// only 404/410 prune outright).
 pub async fn mark_web_push_failure(pool: &PgPool, id: i64) -> Result<()> {
-    sqlx::query("UPDATE web_push_subscriptions SET failure_count = failure_count + 1 WHERE id = $1")
-        .bind(id)
-        .execute(pool)
-        .await?;
+    sqlx::query(
+        "UPDATE web_push_subscriptions SET failure_count = failure_count + 1 WHERE id = $1",
+    )
+    .bind(id)
+    .execute(pool)
+    .await?;
     Ok(())
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -520,8 +520,7 @@ fn spawn_retention_prune_task(
             tracing::warn!(error = %e, "initial auxiliary retention prune failed");
         }
         if let Some(d) = screen_history_days {
-            if let Err(e) =
-                db::prune_screen_history(&pool_retention, &screen_history_dir, d).await
+            if let Err(e) = db::prune_screen_history(&pool_retention, &screen_history_dir, d).await
             {
                 tracing::warn!(error = %e, "initial screen-history prune failed");
             }

--- a/server/src/notify/slack.rs
+++ b/server/src/notify/slack.rs
@@ -38,7 +38,11 @@ impl AlertNotifier for SlackNotifier {
     }
 
     async fn notify_alert_match(&self, payload: &AlertMatchPayload) -> anyhow::Result<()> {
-        let mut text = format!("*{}*\n{}", message::title(payload), message::summary(payload));
+        let mut text = format!(
+            "*{}*\n{}",
+            message::title(payload),
+            message::summary(payload)
+        );
         if let Some(l) = message::link(payload) {
             text.push_str(&format!("\n<{l}|Open in Vantyr>"));
         }

--- a/server/src/notify/webhook.rs
+++ b/server/src/notify/webhook.rs
@@ -28,10 +28,11 @@ impl WebhookNotifier {
             );
             return None;
         }
-        let auth_header = env_trim("NOTIFY_WEBHOOK_AUTH_HEADER").map(|raw| match raw.split_once(':') {
-            Some((k, v)) => (k.trim().to_string(), v.trim().to_string()),
-            None => ("Authorization".to_string(), raw),
-        });
+        let auth_header =
+            env_trim("NOTIFY_WEBHOOK_AUTH_HEADER").map(|raw| match raw.split_once(':') {
+                Some((k, v)) => (k.trim().to_string(), v.trim().to_string()),
+                None => ("Authorization".to_string(), raw),
+            });
         Some(Self {
             client: http_client(),
             url,

--- a/server/src/screen_narrative.rs
+++ b/server/src/screen_narrative.rs
@@ -89,7 +89,9 @@ async fn run_once(state: &Arc<AppState>) -> anyhow::Result<()> {
     let mut in_flight = FuturesUnordered::new();
     loop {
         while in_flight.len() < MAX_CONCURRENT_AGENTS {
-            let Some(agent_id) = pending.next() else { break };
+            let Some(agent_id) = pending.next() else {
+                break;
+            };
             in_flight.push(summarize_agent(state, agent_id, now));
         }
         if in_flight.next().await.is_none() {
@@ -186,10 +188,7 @@ async fn summarize_agent_day(
 
     // Nothing new happened and we already have a narrative. Skip unless the day just
     // ended and still needs its finalizing pass.
-    if unchanged
-        && state_row.as_ref().is_some_and(|s| s.has_narrative)
-        && !day_is_over
-    {
+    if unchanged && state_row.as_ref().is_some_and(|s| s.has_narrative) && !day_is_over {
         return Ok(());
     }
 
@@ -272,21 +271,59 @@ fn classify(app: &str, title: &str) -> (&'static str, f32) {
     let t = title.to_ascii_lowercase();
     let has = |nks: &[&str]| nks.iter().any(|n| a.contains(n) || t.contains(n));
 
-    if has(&["code", "devenv", "idea", "pycharm", "goland", "rider", "sublime", "vim", "nvim"]) {
+    if has(&[
+        "code", "devenv", "idea", "pycharm", "goland", "rider", "sublime", "vim", "nvim",
+    ]) {
         ("dev", 0.1)
-    } else if has(&["windowsterminal", "powershell", "cmd", "wt.exe", "conhost", "bash", "wsl"]) {
+    } else if has(&[
+        "windowsterminal",
+        "powershell",
+        "cmd",
+        "wt.exe",
+        "conhost",
+        "bash",
+        "wsl",
+    ]) {
         ("terminal", 0.1)
-    } else if has(&["slack", "teams", "discord", "zoom", "outlook", "mail", "telegram", "whatsapp"]) {
+    } else if has(&[
+        "slack", "teams", "discord", "zoom", "outlook", "mail", "telegram", "whatsapp",
+    ]) {
         ("comms", 0.4)
     } else if has(&["youtube", "netflix", "spotify", "twitch", "vlc"]) {
         ("media", 0.9)
-    } else if has(&["figma", "photoshop", "illustrator", "blender", "sketch", "affinity"]) {
+    } else if has(&[
+        "figma",
+        "photoshop",
+        "illustrator",
+        "blender",
+        "sketch",
+        "affinity",
+    ]) {
         ("design", 0.2)
-    } else if has(&["word", "excel", "powerpoint", "acrobat", "notion", "obsidian", "docs", "sheets"]) {
+    } else if has(&[
+        "word",
+        "excel",
+        "powerpoint",
+        "acrobat",
+        "notion",
+        "obsidian",
+        "docs",
+        "sheets",
+    ]) {
         ("docs", 0.2)
-    } else if has(&["chrome", "firefox", "edge", "msedge", "brave", "opera", "safari"]) {
+    } else if has(&[
+        "chrome", "firefox", "edge", "msedge", "brave", "opera", "safari",
+    ]) {
         // Social/entertainment sites bump distraction even inside a browser.
-        if has(&["facebook", "instagram", "tiktok", "reddit", "twitter", "x.com", "9gag"]) {
+        if has(&[
+            "facebook",
+            "instagram",
+            "tiktok",
+            "reddit",
+            "twitter",
+            "x.com",
+            "9gag",
+        ]) {
             ("media", 0.85)
         } else {
             ("browsing", 0.5)
@@ -343,9 +380,7 @@ fn build_segments(focus: &[FocusRow], upper: DateTime<Utc>) -> Vec<SegmentInput>
     segs
 }
 
-fn aggregate(
-    segs: &[SegmentInput],
-) -> (serde_json::Value, serde_json::Value, serde_json::Value) {
+fn aggregate(segs: &[SegmentInput]) -> (serde_json::Value, serde_json::Value, serde_json::Value) {
     use std::collections::HashMap;
     let mut by_category: HashMap<&str, i64> = HashMap::new();
     let mut by_app: HashMap<String, i64> = HashMap::new();
@@ -366,7 +401,7 @@ fn aggregate(
     });
 
     let mut apps: Vec<(String, i64)> = by_app.into_iter().collect();
-    apps.sort_by(|a, b| b.1.cmp(&a.1));
+    apps.sort_by_key(|(_, secs)| std::cmp::Reverse(*secs));
     let top_apps: Vec<serde_json::Value> = apps
         .into_iter()
         .take(6)
@@ -389,7 +424,11 @@ fn aggregate(
         })
         .collect();
 
-    (totals, serde_json::json!(top_apps), serde_json::json!(highlights))
+    (
+        totals,
+        serde_json::json!(top_apps),
+        serde_json::json!(highlights),
+    )
 }
 
 /// Rule-based prose narrative. Deliberately qualitative — no durations or counts;
@@ -416,7 +455,7 @@ fn rule_based_narrative(
                 .collect()
         })
         .unwrap_or_default();
-    cats.sort_by(|a, b| b.1.cmp(&a.1));
+    cats.sort_by_key(|(_, secs)| std::cmp::Reverse(*secs));
     let cat_words: Vec<String> = cats
         .iter()
         .take(3)
@@ -583,8 +622,14 @@ mod tests {
 
     #[test]
     fn identical_segments_hash_identically() {
-        let a = vec![seg(0, 60, "dev", "code.exe"), seg(60, 120, "comms", "slack.exe")];
-        let b = vec![seg(0, 60, "dev", "code.exe"), seg(60, 120, "comms", "slack.exe")];
+        let a = vec![
+            seg(0, 60, "dev", "code.exe"),
+            seg(60, 120, "comms", "slack.exe"),
+        ];
+        let b = vec![
+            seg(0, 60, "dev", "code.exe"),
+            seg(60, 120, "comms", "slack.exe"),
+        ];
         assert_eq!(segments_fingerprint(&a), segments_fingerprint(&b));
     }
 
@@ -600,7 +645,10 @@ mod tests {
     #[test]
     fn a_new_segment_changes_the_hash() {
         let before = vec![seg(0, 60, "dev", "code.exe")];
-        let after = vec![seg(0, 60, "dev", "code.exe"), seg(60, 120, "media", "vlc.exe")];
+        let after = vec![
+            seg(0, 60, "dev", "code.exe"),
+            seg(60, 120, "media", "vlc.exe"),
+        ];
         assert_ne!(segments_fingerprint(&before), segments_fingerprint(&after));
     }
 

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -581,11 +581,23 @@ mod recall_audit_tests {
         let (viewer_a, viewer_b) = (Uuid::from_u128(1), Uuid::from_u128(2));
         let (agent_a, agent_b) = (Uuid::from_u128(10), Uuid::from_u128(11));
 
-        assert!(recall_audit_decision(&mut seen, (viewer_a, agent_a, ACTION), t));
+        assert!(recall_audit_decision(
+            &mut seen,
+            (viewer_a, agent_a, ACTION),
+            t
+        ));
         // A second operator watching the same agent must produce its own row.
-        assert!(recall_audit_decision(&mut seen, (viewer_b, agent_a, ACTION), t));
+        assert!(recall_audit_decision(
+            &mut seen,
+            (viewer_b, agent_a, ACTION),
+            t
+        ));
         // Same operator, different agent: separate row.
-        assert!(recall_audit_decision(&mut seen, (viewer_a, agent_b, ACTION), t));
+        assert!(recall_audit_decision(
+            &mut seen,
+            (viewer_a, agent_b, ACTION),
+            t
+        ));
         // Same operator+agent, different action: separate row.
         assert!(recall_audit_decision(
             &mut seen,
@@ -593,7 +605,11 @@ mod recall_audit_tests {
             t
         ));
         // ...and each is now throttled independently.
-        assert!(!recall_audit_decision(&mut seen, (viewer_a, agent_a, ACTION), t));
+        assert!(!recall_audit_decision(
+            &mut seen,
+            (viewer_a, agent_a, ACTION),
+            t
+        ));
     }
 
     #[test]

--- a/server/src/ws_agent.rs
+++ b/server/src/ws_agent.rs
@@ -883,9 +883,7 @@ async fn ingest_history_frame_binary(agent_id: Uuid, frame: &[u8], state: &Arc<A
 ///
 /// Pure so the wire format can be tested directly: a mismatch between this and the
 /// agent's encoder would silently drop every keyframe on the floor.
-fn parse_history_frame_binary(
-    frame: &[u8],
-) -> Result<(serde_json::Value, Vec<u8>), &'static str> {
+fn parse_history_frame_binary(frame: &[u8]) -> Result<(serde_json::Value, Vec<u8>), &'static str> {
     const PREFIX: usize = 8; // magic + u32 header length
     if frame.len() < PREFIX {
         return Err("truncated header");
@@ -955,7 +953,10 @@ async fn store_history_frame(
     let day = captured_at.format("%Y%m%d").to_string();
     let file = format!("{}.jpg", Uuid::new_v4());
     let rel = format!("{agent_id}/{day}/{file}");
-    let dir = state.screen_history_dir.join(agent_id.to_string()).join(&day);
+    let dir = state
+        .screen_history_dir
+        .join(agent_id.to_string())
+        .join(&day);
     let path = dir.join(&file);
 
     // Filesystem writes are blocking; keep them off the async reactor.


### PR DESCRIPTION
The release workflow's quality gates were failing on `main` before this, which
would have blocked the `v0.1.1` tag build. All three failures predate the Recall
work merged in #16.

**`cargo fmt --all --check`** — `api/push.rs`, `config.rs`, `main.rs`, the notify
backends and several agent modules were unformatted. Applied rustfmt across
server and agent.

**`cargo clippy -p vantyr-server -- -D warnings`** — two `unnecessary_sort_by`
errors in the narrative worker, now `sort_by_key(Reverse(..))`.

**`npm run lint` in `agent/ui-src`** — the Logs pane's log-tail effect tripped
`react-hooks/set-state-in-effect`. `refreshLogs` only touches state after
awaiting the IPC read, but the rule flags any effect that transitively sets
state. Disabled at that one call site with a comment rather than restructuring
the fetch.

No behaviour change.

### Verified locally on this branch
- `cargo fmt --all --check` (server) and `cargo fmt --check` (agent): pass
- `cargo clippy -p vantyr-server -- -D warnings`: 0 errors
- `cargo test -p vantyr-server`: 49/49
- `agent/ui-src`: lint 0 errors, build passes
- `frontend`: lint 0 errors (1 pre-existing warning), 17/17 tests, build passes